### PR TITLE
Improve agent keyboards layout

### DIFF
--- a/commands/saldo.js
+++ b/commands/saldo.js
@@ -50,7 +50,18 @@ const saldoWizard = new Scenes.WizardScene(
       await ctx.reply('⚠️ No hay agentes registrados.');
       return ctx.scene.leave();
     }
-    const kb = agentes.map(a => [Markup.button.callback(a.nombre, `AG_${a.id}`)]);
+    const kb = [];
+    for (let i = 0; i < agentes.length; i += 2) {
+      const row = [
+        Markup.button.callback(agentes[i].nombre, `AG_${agentes[i].id}`)
+      ];
+      if (agentes[i + 1]) {
+        row.push(
+          Markup.button.callback(agentes[i + 1].nombre, `AG_${agentes[i + 1].id}`)
+        );
+      }
+      kb.push(row);
+    }
     await ctx.reply('👤 Selecciona un agente:', Markup.inlineKeyboard(kb));
     return ctx.wizard.next();
   },

--- a/commands/tarjeta_wizard.js
+++ b/commands/tarjeta_wizard.js
@@ -44,7 +44,18 @@ const tarjetaWizard = new Scenes.WizardScene(
       await ctx.reply('⚠️ No hay agentes. Crea uno con /agentes y vuelve a /tarjeta.');
       return ctx.scene.leave();
     }
-    const kb = agents.map(a => [Markup.button.callback(a.nombre, `AG_${a.id}`)]);
+    const kb = [];
+    for (let i = 0; i < agents.length; i += 2) {
+      const row = [
+        Markup.button.callback(agents[i].nombre, `AG_${agents[i].id}`)
+      ];
+      if (agents[i + 1]) {
+        row.push(
+          Markup.button.callback(agents[i + 1].nombre, `AG_${agents[i + 1].id}`)
+        );
+      }
+      kb.push(row);
+    }
     await ctx.reply('👤 Elige agente:', Markup.inlineKeyboard(kb));
     return ctx.wizard.next();
   },


### PR DESCRIPTION
## Summary
- display agents two per row in tarjeta wizard
- display agents two per row in saldo wizard

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688d2d576100832d8abec20913339ea0