### PR TITLE
feat: mejorar asistente de saldo

### DIFF
--- a/commands/saldo.js
+++ b/commands/saldo.js
@@ -17,6 +17,12 @@ const kbCancel = Markup.inlineKeyboard([
   Markup.button.callback('❌ Cancelar', 'GLOBAL_CANCEL')
 ]);
 
+const kbContinue = Markup.inlineKeyboard([
+  [Markup.button.callback('🔄 Otra tarjeta', 'OTRA_TA')],
+  [Markup.button.callback('👥 Otros agentes', 'OTROS_AG')],
+  [Markup.button.callback('❌ Finalizar', 'GLOBAL_CANCEL')]
+]);
+
 async function wantExit(ctx) {
   if (ctx.callbackQuery?.data === 'GLOBAL_CANCEL') {
     await ctx.answerCbQuery().catch(() => {});
@@ -37,33 +43,120 @@ async function wantExit(ctx) {
   return false;
 }
 
+async function showAgentes(ctx) {
+  const agentes = (
+    await pool.query('SELECT id,nombre FROM agente ORDER BY nombre')
+  ).rows;
+  if (!agentes.length) {
+    await ctx.reply('⚠️ No hay agentes registrados.');
+    return false;
+  }
+  const kb = [];
+  for (let i = 0; i < agentes.length; i += 2) {
+    const row = [Markup.button.callback(agentes[i].nombre, `AG_${agentes[i].id}`)];
+    if (agentes[i + 1]) {
+      row.push(
+        Markup.button.callback(agentes[i + 1].nombre, `AG_${agentes[i + 1].id}`)
+      );
+    }
+    kb.push(row);
+  }
+  kb.push([Markup.button.callback('❌ Cancelar', 'GLOBAL_CANCEL')]);
+  const txt = '👥 *Seleccione uno de los Agentes disponibles*';
+  const extra = { parse_mode: 'Markdown', ...Markup.inlineKeyboard(kb) };
+  if (ctx.wizard.state.data?.msgId) {
+    await ctx.telegram.editMessageText(
+      ctx.chat.id,
+      ctx.wizard.state.data.msgId,
+      undefined,
+      txt,
+      extra
+    );
+  } else {
+    const msg = await ctx.reply(txt, extra);
+    ctx.wizard.state.data = { msgId: msg.message_id };
+  }
+  return true;
+}
+
+async function showTarjetas(ctx) {
+  const { agente_id } = ctx.wizard.state.data;
+  const tarjetas = (
+    await pool.query(
+      `
+      SELECT t.id, t.numero,
+             COALESCE(mv.saldo_nuevo,0) AS saldo,
+             COALESCE(m.codigo,'')       AS moneda,
+             COALESCE(m.emoji,'')        AS moneda_emoji
+      FROM tarjeta t
+      LEFT JOIN moneda m  ON m.id = t.moneda_id
+      LEFT JOIN LATERAL (
+        SELECT saldo_nuevo
+          FROM movimiento
+          WHERE tarjeta_id = t.id
+          ORDER BY creado_en DESC
+          LIMIT 1
+      ) mv ON true
+      WHERE t.agente_id = $1
+      ORDER BY t.numero;`,
+      [agente_id]
+    )
+  ).rows;
+
+  if (!tarjetas.length) {
+    await ctx.telegram.editMessageText(
+      ctx.chat.id,
+      ctx.wizard.state.data.msgId,
+      undefined,
+      'Este agente todavía no tiene tarjetas.',
+      { parse_mode: 'Markdown' }
+    );
+    await ctx.scene.leave();
+    return false;
+  }
+
+  const kb = tarjetas.map(t => [
+    Markup.button.callback(
+      `${t.numero}  (${t.moneda_emoji} ${t.moneda} – ${t.saldo})`,
+      `TA_${t.id}`
+    )
+  ]);
+  kb.push([Markup.button.callback('❌ Cancelar', 'GLOBAL_CANCEL')]);
+  const txt = '💳 *Elija la tarjeta a actualizar de este agente*';
+  await ctx.telegram.editMessageText(
+    ctx.chat.id,
+    ctx.wizard.state.data.msgId,
+    undefined,
+    txt,
+    { parse_mode: 'Markdown', ...Markup.inlineKeyboard(kb) }
+  );
+  ctx.wizard.state.data.tarjetas = tarjetas; // caché
+  return true;
+}
+
+async function askSaldo(ctx, tarjeta) {
+  const txt =
+    `✏️ *Introduce el saldo actual de tu tarjeta*\n\n` +
+    `Tarjeta ${tarjeta.numero} (saldo anterior: ${tarjeta.saldo}).\n` +
+    `Por favor coloca el saldo actual de tu tarjeta. No te preocupes, te diré si ha aumentado o disminuido y en cuánto.\n\n` +
+    `Ejemplo: 1500.50`;
+  await ctx.telegram.editMessageText(
+    ctx.chat.id,
+    ctx.wizard.state.data.msgId,
+    undefined,
+    txt,
+    { parse_mode: 'Markdown', ...kbCancel }
+  );
+}
+
 /* ───────── Wizard ───────── */
 const saldoWizard = new Scenes.WizardScene(
   'SALDO_WIZ',
 
-  /* 0 – elegir agente */
+  /* 0 – mostrar agentes */
   async ctx => {
-    const agentes = (
-      await pool.query('SELECT id,nombre FROM agente ORDER BY nombre')
-    ).rows;
-    if (!agentes.length) {
-      await ctx.reply('⚠️ No hay agentes registrados.');
-      return ctx.scene.leave();
-    }
-    const kb = [];
-    for (let i = 0; i < agentes.length; i += 2) {
-      const row = [
-        Markup.button.callback(agentes[i].nombre, `AG_${agentes[i].id}`)
-      ];
-      if (agentes[i + 1]) {
-        row.push(
-          Markup.button.callback(agentes[i + 1].nombre, `AG_${agentes[i + 1].id}`)
-        );
-      }
-      kb.push(row);
-    }
-    kb.push([Markup.button.callback('❌ Cancelar', 'GLOBAL_CANCEL')]);
-    await ctx.reply('👤 Selecciona un agente:', Markup.inlineKeyboard(kb));
+    const ok = await showAgentes(ctx);
+    if (!ok) return ctx.scene.leave();
     return ctx.wizard.next();
   },
 
@@ -75,45 +168,10 @@ const saldoWizard = new Scenes.WizardScene(
     }
     await ctx.answerCbQuery().catch(() => {});
     const agente_id = +ctx.callbackQuery.data.split('_')[1];
-    ctx.wizard.state.data = { agente_id };
+    ctx.wizard.state.data.agente_id = agente_id;
 
-    const tarjetas = (
-      await pool.query(
-        `
-        SELECT t.id, t.numero,
-               COALESCE(mv.saldo_nuevo,0) AS saldo,
-               COALESCE(m.codigo,'')       AS moneda,
-               COALESCE(m.emoji,'')        AS moneda_emoji
-        FROM tarjeta t
-        LEFT JOIN moneda m  ON m.id = t.moneda_id
-        LEFT JOIN LATERAL (
-          SELECT saldo_nuevo
-            FROM movimiento
-            WHERE tarjeta_id = t.id
-            ORDER BY creado_en DESC
-            LIMIT 1
-        ) mv ON true
-        WHERE t.agente_id = $1
-        ORDER BY t.numero;`,
-        [agente_id]
-      )
-    ).rows;
-
-    if (!tarjetas.length) {
-      await ctx.reply('Este agente todavía no tiene tarjetas.');
-      return ctx.scene.leave();
-    }
-
-    // mostrar lista y botones
-    const kb = tarjetas.map(t => [
-      Markup.button.callback(
-        `${t.numero}  (${t.moneda_emoji} ${t.moneda} – ${t.saldo})`,
-        `TA_${t.id}`
-      )
-    ]);
-    kb.push([Markup.button.callback('❌ Cancelar', 'GLOBAL_CANCEL')]);
-    ctx.wizard.state.data.tarjetas = tarjetas; // caché
-    await ctx.reply('💳 Selecciona la tarjeta a actualizar:', Markup.inlineKeyboard(kb));
+    const ok = await showTarjetas(ctx);
+    if (!ok) return; // escena ya cerrada si no hay tarjetas
     return ctx.wizard.next();
   },
 
@@ -128,14 +186,11 @@ const saldoWizard = new Scenes.WizardScene(
     const tarjeta = ctx.wizard.state.data.tarjetas.find(t => t.id === tarjeta_id);
 
     ctx.wizard.state.data.tarjeta = tarjeta;
-    await ctx.reply(
-      `✏️ Saldo actual para ${tarjeta.numero} (antes ${tarjeta.saldo}):`,
-      kbCancel
-    );
+    await askSaldo(ctx, tarjeta);
     return ctx.wizard.next();
   },
 
-  /* 3 – registrar movimiento */
+  /* 3 – registrar movimiento y preguntar continuación */
   async ctx => {
     if (await wantExit(ctx)) return;
     const num = parseFloat((ctx.message?.text || '').replace(',', '.'));
@@ -161,19 +216,50 @@ const saldoWizard = new Scenes.WizardScene(
         );
         `,
         [tarjeta.id, saldoAnterior, delta, saldoNuevo]
-        );
+      );
 
-      const signo = delta > 0 ? '📈 Aumentó' : delta < 0 ? '📉 Disminuyó' : '➖ Sin cambio';
-      await ctx.reply(
-        `${signo} ${Math.abs(delta).toFixed(2)}.\n` +
-          `Saldo nuevo de *${tarjeta.numero}*: ${saldoNuevo.toFixed(2)} ${tarjeta.moneda}`,
-        { parse_mode: 'Markdown' }
+      const signo =
+        delta > 0 ? '📈 Aumentó' : delta < 0 ? '📉 Disminuyó' : '➖ Sin cambio';
+      const txt =
+        `${signo} ${Math.abs(delta).toFixed(2)} ${tarjeta.moneda}.\n` +
+        `Saldo nuevo de *${tarjeta.numero}*: ${saldoNuevo.toFixed(2)} ${tarjeta.moneda}.\n\n` +
+        `¿Deseas actualizar otra tarjeta?`;
+      await ctx.telegram.editMessageText(
+        ctx.chat.id,
+        ctx.wizard.state.data.msgId,
+        undefined,
+        txt,
+        { parse_mode: 'Markdown', ...kbContinue }
       );
     } catch (e) {
       console.error('[SALDO_WIZ] error insert movimiento:', e);
       await ctx.reply('❌ No se pudo registrar el movimiento.');
+      return ctx.scene.leave();
     }
-    return ctx.scene.leave();
+
+    return ctx.wizard.next();
+  },
+
+  /* 4 – decidir si continuar o salir */
+  async ctx => {
+    if (await wantExit(ctx)) return;
+    if (!ctx.callbackQuery) return;
+    const { data } = ctx.callbackQuery;
+    await ctx.answerCbQuery().catch(() => {});
+
+    if (data === 'OTRA_TA') {
+      const ok = await showTarjetas(ctx);
+      if (ok) return ctx.wizard.selectStep(2);
+      return;
+    }
+
+    if (data === 'OTROS_AG') {
+      const ok = await showAgentes(ctx);
+      if (ok) return ctx.wizard.selectStep(1);
+      return;
+    }
+
+    return ctx.reply('Usa los botones para continuar.');
   }
 );
 


### PR DESCRIPTION
## Summary
- refine saldo wizard with inline edits to avoid message spam
- provide clearer headings and instructions with emojis
- allow repeating updates or switching agents after recording balance

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688dc5b2b2f4832d83ca94cc623c5156