### PR TITLE
fix: escape markdown and add monitor menu

### DIFF
--- a/app.js
+++ b/app.js
@@ -41,7 +41,7 @@ const registerAgente  = require('./commands/agente');
 const tarjetaWizard   = require('./commands/tarjeta_wizard');
 const saldoWizard     = require('./commands/saldo');
 const tarjetasAssist  = require('./commands/tarjetas_assist');
-const { registerMonitor } = require('./commands/monitor');
+const monitorAssist   = require('./commands/monitor_assist');
 
 /* ───────── 6. Inicializar BD (idempotente) ───────── */
 (async () => {
@@ -50,7 +50,7 @@ const { registerMonitor } = require('./commands/monitor');
 })();
 
 /* ───────── 7. Scenes / Stage ───────── */
-const stage = new Scenes.Stage([tarjetaWizard, saldoWizard, tarjetasAssist], { ttl: 300 });
+const stage = new Scenes.Stage([tarjetaWizard, saldoWizard, tarjetasAssist, monitorAssist], { ttl: 300 });
 bot.use(session());
 bot.use(stage.middleware());
 
@@ -58,7 +58,6 @@ bot.use(stage.middleware());
 registerMoneda(bot, stage);
 registerBanco(bot, stage);
 registerAgente(bot, stage);
-registerMonitor(bot);  
 
 /* ───────── 8. Middleware de verificación de acceso ───────── */
 const verificarAcceso = async (ctx, next) => {
@@ -117,6 +116,7 @@ bot.command('agentes',  (ctx) => ctx.scene.enter('AGENTE_WIZ'));
 bot.command('tarjeta',  (ctx) => ctx.scene.enter('TARJETA_WIZ'));
 bot.command('saldo',    (ctx) => ctx.scene.enter('SALDO_WIZ'));
 bot.command('tarjetas', (ctx) => ctx.scene.enter('TARJETAS_ASSIST'));
+bot.command('monitor',  (ctx) => ctx.scene.enter('MONITOR_ASSIST'));
 
 /* ───────── 13. Gestión de accesos (solo OWNER) ───────── */
 bot.command('daracceso', safe(async (ctx) => {

--- a/commands/monitor.js
+++ b/commands/monitor.js
@@ -424,11 +424,7 @@ async function runMonitor(ctx, rawText) {
   }
 }
 
-function registerMonitor(bot) {
-  bot.command('monitor', (ctx) => runMonitor(ctx, ctx.message?.text || ''));
-}
-
-module.exports = { registerMonitor, runMonitor };
+module.exports = { runMonitor };
 
 // Comentarios de modificaciones:
 // - Se implementó el comando /monitor con soporte de rangos (día, semana, mes, año).

--- a/commands/monitor_assist.js
+++ b/commands/monitor_assist.js
@@ -1,0 +1,56 @@
+/**
+ * commands/monitor_assist.js
+ *
+ * Wizard interactivo para el comando /monitor.
+ * Muestra un menú de periodos y delega en runMonitor para generar los reportes.
+ */
+
+const { Scenes, Markup } = require('telegraf');
+const { runMonitor } = require('./monitor');
+
+function mainMenu() {
+  return Markup.inlineKeyboard([
+    [Markup.button.callback('📊 Día', 'PER_dia')],
+    [Markup.button.callback('📆 Semana', 'PER_semana')],
+    [Markup.button.callback('📅 Mes', 'PER_mes')],
+    [Markup.button.callback('🗓 Año', 'PER_ano')],
+    [Markup.button.callback('❌ Salir', 'EXIT')],
+  ]);
+}
+
+const monitorAssist = new Scenes.WizardScene(
+  'MONITOR_ASSIST',
+  async (ctx) => {
+    const msg = await ctx.reply(
+      '📈 *Monitor*\nElige el periodo que deseas consultar:',
+      { parse_mode: 'MarkdownV2', ...mainMenu() }
+    );
+    ctx.wizard.state.msgId = msg.message_id;
+    return ctx.wizard.next();
+  },
+  async (ctx) => {
+    const data = ctx.callbackQuery?.data;
+    if (!data) return;
+    await ctx.answerCbQuery().catch(() => {});
+    if (data === 'EXIT') {
+      await ctx.telegram.editMessageText(
+        ctx.chat.id,
+        ctx.wizard.state.msgId,
+        undefined,
+        '❌ Operación cancelada.'
+      );
+      return ctx.scene.leave();
+    }
+    const periodo = data.split('_')[1];
+    await ctx.telegram.editMessageText(
+      ctx.chat.id,
+      ctx.wizard.state.msgId,
+      undefined,
+      'Generando reporte...'
+    );
+    await runMonitor(ctx, `/monitor ${periodo}`);
+    return ctx.scene.leave();
+  }
+);
+
+module.exports = monitorAssist;

--- a/commands/tarjetas_assist.js
+++ b/commands/tarjetas_assist.js
@@ -16,14 +16,16 @@ const LINES_PER_PAGE = 12; // Líneas máximas por página
 const MAX_LEN = Telegram.MAX_MESSAGE_LENGTH;
 
 /* ───────── helpers ───────── */
-const fmt = (v, d = 2) =>
-  Number(v || 0).toLocaleString('en-US', {
-    minimumFractionDigits: d,
-    maximumFractionDigits: d,
-  });
-
 const mdEscape = (s) =>
   String(s ?? '').replace(/[_*`[\]()~>#+\-=|{}.!]/g, '\\$&');
+
+const fmt = (v, d = 2) =>
+  mdEscape(
+    Number(v || 0).toLocaleString('en-US', {
+      minimumFractionDigits: d,
+      maximumFractionDigits: d,
+    })
+  );
 
 function paginate(text, linesPerPage = LINES_PER_PAGE) {
   const lines = text.split('\n');


### PR DESCRIPTION
## Summary
- escape numeric values in tarjetas assistant to avoid MarkdownV2 parse errors
- add simple wizard menu for /monitor to choose reporting period
- register monitor wizard and remove old direct command handler

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688dcdc6c28c832d8ea73b9ce0e0379d