### PR TITLE
feat: restructure tarjetas and monitor assistants

### DIFF
--- a/commands/tarjetas_assist.js
+++ b/commands/tarjetas_assist.js
@@ -1,23 +1,31 @@
 /**
  * commands/tarjetas_assist.js
  *
- * Asistente interactivo para listar tarjetas en un solo mensaje.
+ * Asistente interactivo para listar tarjetas sin generar mensajes nuevos.
  *
- * Migrado a parse mode HTML. El helper escapeHtml se encarga de sanear los
- * valores dinámicos para evitar errores de parseo e inyecciones. Si se
- * necesitara volver a Markdown, ajustar los textos y parse_mode.
+ * Correcciones principales:
+ * - Se añadió editIfChanged para evitar "400: message is not modified".
+ * - Separación de bloques por agente y por combinación moneda+banco.
+ * - Navegación jerárquica con botones Volver/Salir y paginación por entidad.
  *
- * README: Ajusta `LINES_PER_PAGE` para cambiar cuántas líneas se muestran
- * por página. Para añadir nuevas vistas al menú principal, agrega una
- * opción en `showMenu` y maneja su lógica en `buildView`.
+ * Todo usa parse mode HTML y escapeHtml para sanear entradas dinámicas.
+ * Las vistas se pueden extender añadiendo nuevas rutas en showMenu/builders.
+ *
+ * Casos de prueba manuales:
+ * - `/tarjetas` → "Por agente" → elegir un agente → validar que solo se
+ *   muestran sus monedas y tarjetas.
+ * - "Por moneda y banco" → elegir moneda → banco → detalle sin mezclar otras
+ *   combinaciones.
+ * - Navegar con Siguiente/Anterior sin provocar "message is not modified".
  */
 
 const { Scenes, Markup, Telegram } = require('telegraf');
 const { escapeHtml } = require('../helpers/format');
+const { editIfChanged, buildNavKeyboard, buildBackExitRow } = require('../helpers/ui');
 const pool = require('../psql/db.js');
 
 /* Configuración */
-const LINES_PER_PAGE = 12; // Líneas máximas por página
+const LINES_PER_PAGE = 12; // Líneas máximas por página para detalles largos
 const MAX_LEN = Telegram.MAX_MESSAGE_LENGTH;
 
 /* ───────── helpers ───────── */
@@ -36,10 +44,7 @@ function paginate(text, linesPerPage = LINES_PER_PAGE) {
   let count = 0;
   for (const line of lines) {
     const nl = line + '\n';
-    if (
-      count >= linesPerPage ||
-      (buf + nl).length > MAX_LEN
-    ) {
+    if (count >= linesPerPage || (buf + nl).length > MAX_LEN) {
       pages.push(buf.trimEnd());
       buf = '';
       count = 0;
@@ -55,17 +60,13 @@ async function wantExit(ctx) {
   if (ctx.callbackQuery?.data === 'EXIT') {
     await ctx.answerCbQuery().catch(() => {});
     const msgId = ctx.wizard.state.msgId;
-    if (msgId) {
-      await ctx.telegram.editMessageText(
-        ctx.chat.id,
-        msgId,
-        undefined,
-        '❌ Operación cancelada.',
-        { parse_mode: 'HTML' }
-      );
-    } else {
-      await ctx.reply('❌ Operación cancelada.');
-    }
+    await ctx.telegram.editMessageText(
+      ctx.chat.id,
+      msgId,
+      undefined,
+      '❌ Operación cancelada.',
+      { parse_mode: 'HTML' }
+    );
     await ctx.scene.leave();
     return true;
   }
@@ -73,17 +74,13 @@ async function wantExit(ctx) {
     const t = ctx.message.text.trim().toLowerCase();
     if (['/cancel', '/salir', 'salir'].includes(t) && ctx.scene?.current) {
       const msgId = ctx.wizard.state.msgId;
-      if (msgId) {
-        await ctx.telegram.editMessageText(
-          ctx.chat.id,
-          msgId,
-          undefined,
-          '❌ Operación cancelada.',
-          { parse_mode: 'HTML' }
-        );
-      } else {
-        await ctx.reply('❌ Operación cancelada.');
-      }
+      await ctx.telegram.editMessageText(
+        ctx.chat.id,
+        msgId,
+        undefined,
+        '❌ Operación cancelada.',
+        { parse_mode: 'HTML' }
+      );
       await ctx.scene.leave();
       return true;
     }
@@ -91,279 +88,380 @@ async function wantExit(ctx) {
   return false;
 }
 
-function navKeyboard(total) {
-  return Markup.inlineKeyboard([
-    [
-      Markup.button.callback('⏮️', 'FIRST'),
-      Markup.button.callback('◀️', 'PREV'),
-      Markup.button.callback('▶️', 'NEXT'),
-      Markup.button.callback('⏭️', 'LAST'),
-    ],
-    [
-      Markup.button.callback('🔙 Volver', 'BACK'),
-      Markup.button.callback('❌ Salir', 'EXIT'),
-    ],
-  ]);
+async function loadData() {
+  const sql = `
+    SELECT t.id, t.numero, t.agente_id,
+           COALESCE(ag.nombre,'—') AS agente,
+           COALESCE(ag.emoji,'')   AS agente_emoji,
+           COALESCE(b.id,0)        AS banco_id,
+           COALESCE(b.codigo,'Sin banco') AS banco,
+           COALESCE(b.emoji,'')    AS banco_emoji,
+           COALESCE(m.codigo,'—')  AS moneda,
+           COALESCE(m.emoji,'')    AS moneda_emoji,
+           COALESCE(m.tasa_usd,1)  AS tasa_usd,
+           COALESCE(mv.saldo_nuevo,0) AS saldo
+      FROM tarjeta t
+      LEFT JOIN agente ag ON ag.id = t.agente_id
+      LEFT JOIN banco  b  ON b.id = t.banco_id
+      LEFT JOIN moneda m  ON m.id = t.moneda_id
+      LEFT JOIN LATERAL (
+        SELECT saldo_nuevo
+          FROM movimiento
+          WHERE tarjeta_id = t.id
+          ORDER BY creado_en DESC
+          LIMIT 1
+      ) mv ON TRUE;`;
+  const rows = (await pool.query(sql)).rows;
+  const byAgent = {};
+  const byMon = {};
+  const bankUsd = {};
+  let globalUsd = 0;
+
+  rows.forEach((r) => {
+    const usd = r.saldo * r.tasa_usd;
+    globalUsd += usd;
+    bankUsd[r.banco] = (bankUsd[r.banco] || 0) + usd;
+
+    byAgent[r.agente_id] ??= {
+      id: r.agente_id,
+      nombre: r.agente,
+      emoji: r.agente_emoji,
+      totalUsd: 0,
+      perMon: {},
+    };
+    const ag = byAgent[r.agente_id];
+    ag.totalUsd += usd;
+    ag.perMon[r.moneda] ??= {
+      code: r.moneda,
+      emoji: r.moneda_emoji,
+      rate: r.tasa_usd,
+      tarjetas: [],
+      total: 0,
+    };
+    ag.perMon[r.moneda].tarjetas.push({
+      numero: r.numero,
+      saldo: r.saldo,
+      banco: r.banco,
+      banco_emoji: r.banco_emoji,
+    });
+    ag.perMon[r.moneda].total += r.saldo;
+
+    byMon[r.moneda] ??= {
+      code: r.moneda,
+      emoji: r.moneda_emoji,
+      rate: r.tasa_usd,
+      banks: {},
+    };
+    const mon = byMon[r.moneda];
+    mon.banks[r.banco] ??= {
+      code: r.banco,
+      emoji: r.banco_emoji,
+      tarjetas: [],
+      pos: 0,
+      neg: 0,
+    };
+    const bk = mon.banks[r.banco];
+    bk.tarjetas.push({
+      numero: r.numero,
+      saldo: r.saldo,
+      agente: r.agente,
+      agente_emoji: r.agente_emoji,
+    });
+    if (r.saldo >= 0) bk.pos += r.saldo;
+    else bk.neg += r.saldo;
+  });
+
+  return { byAgent, byMon, bankUsd, globalUsd };
 }
 
+/* ───────── renderizadores ───────── */
 async function showMenu(ctx) {
   const kb = Markup.inlineKeyboard([
-    [Markup.button.callback('📊 Por moneda y banco', 'VIEW_MON_BANK')],
+    [Markup.button.callback('📊 Por moneda y banco', 'VIEW_MON')],
     [Markup.button.callback('👤 Por agente', 'VIEW_AGENT')],
     [Markup.button.callback('🧮 Resumen USD global', 'VIEW_SUM')],
     [Markup.button.callback('❌ Salir', 'EXIT')],
   ]);
   const text = '💳 <b>Tarjetas</b>\nElige la vista deseada:';
-  const extra = { parse_mode: 'HTML', ...kb };
-  const msgId = ctx.wizard.state.msgId;
-  if (msgId) {
-    await ctx.telegram.editMessageText(ctx.chat.id, msgId, undefined, text, extra);
-  } else {
-    const msg = await ctx.reply(text, extra);
-    ctx.wizard.state.msgId = msg.message_id;
-  }
-}
-
-function renderPage(ctx) {
-  const pages = ctx.wizard.state.pages || [];
-  const i = ctx.wizard.state.pageIndex || 0;
-  const text = (pages[i] || '—') + `\n\nPágina ${i + 1}/${pages.length}`;
-  return ctx.telegram.editMessageText(
-    ctx.chat.id,
-    ctx.wizard.state.msgId,
-    undefined,
-    text,
-    { parse_mode: 'HTML', ...navKeyboard(pages.length) }
-  );
-}
-
-async function buildView(view) {
-  console.log('[TARJETAS_ASSIST]', 'generando vista', view);
-  const sql = `
-    SELECT t.id, t.numero,
-           COALESCE(ag.nombre,'—')  AS agente,
-           COALESCE(ag.emoji,'')    AS agente_emoji,
-           COALESCE(b.codigo,'Sin banco') AS banco,
-           COALESCE(b.emoji,'')     AS banco_emoji,
-           COALESCE(m.codigo,'—')   AS moneda,
-           COALESCE(m.emoji,'')     AS moneda_emoji,
-           COALESCE(m.tasa_usd,1)   AS tasa_usd,
-           COALESCE(mv.saldo_nuevo,0) AS saldo
-    FROM tarjeta t
-    LEFT JOIN agente  ag ON ag.id = t.agente_id
-    LEFT JOIN banco   b  ON b.id = t.banco_id
-    LEFT JOIN moneda  m  ON m.id = t.moneda_id
-    LEFT JOIN LATERAL (
-      SELECT saldo_nuevo
-      FROM movimiento
-      WHERE tarjeta_id = t.id
-      ORDER BY creado_en DESC
-      LIMIT 1
-    ) mv ON TRUE;`;
-
-  const rows = (await pool.query(sql)).rows;
-  if (!rows.length) {
-    return ['No hay tarjetas registradas todavía.'];
-  }
-
-  const byMon = {};
-  const bankUsd = {};
-  const agentMap = {};
-  let globalUsd = 0;
-
-  rows.forEach((r) => {
-    byMon[r.moneda] ??= {
-      emoji: r.moneda_emoji,
-      rate: +r.tasa_usd,
-      banks: {},
-      totalPos: 0,
-      totalNeg: 0,
-    };
-    const mon = byMon[r.moneda];
-    mon.banks[r.banco] ??= { emoji: r.banco_emoji, filas: [], pos: 0, neg: 0 };
-    const bank = mon.banks[r.banco];
-    bank.filas.push(r);
-
-    if (r.saldo >= 0) {
-      bank.pos += +r.saldo;
-      mon.totalPos += +r.saldo;
-    } else {
-      bank.neg += +r.saldo;
-      mon.totalNeg += +r.saldo;
-    }
-
-    const usd = +r.saldo * mon.rate;
-    bankUsd[r.banco] = (bankUsd[r.banco] || 0) + usd;
-    globalUsd += usd;
-
-    agentMap[r.agente] ??= { emoji: r.agente_emoji, totalUsd: 0, perMon: {} };
-    const ag = agentMap[r.agente];
-    ag.totalUsd += usd;
-    ag.perMon[r.moneda] ??= {
-      total: 0,
-      filas: [],
-      emoji: mon.emoji,
-      rate: mon.rate,
-    };
-    ag.perMon[r.moneda].total += +r.saldo;
-    ag.perMon[r.moneda].filas.push(r);
+  await editIfChanged(ctx, ctx.chat.id, ctx.wizard.state.msgId, text, {
+    parse_mode: 'HTML',
+    ...kb,
   });
+  ctx.wizard.state.route = { view: 'MENU' };
+}
 
-  if (view === 'VIEW_MON_BANK') {
-    const blocks = [];
-    for (const [monCode, info] of Object.entries(byMon)) {
-      const neto = info.totalPos + info.totalNeg;
-      if (neto === 0) continue;
-      let msg = `💱 <b>Moneda:</b> ${info.emoji} ${escapeHtml(monCode)}\n\n`;
-      msg += `📊 <b>Subtotales por banco:</b>\n`;
-      Object.entries(info.banks)
-        .filter(([, d]) => d.pos + d.neg !== 0)
-        .sort(([a], [b]) => a.localeCompare(b))
-        .forEach(([bankCode, data]) => {
-          msg += `\n${data.emoji} <b>${escapeHtml(bankCode)}</b>\n`;
-          data.filas
-            .filter((f) => f.saldo !== 0)
-            .forEach((r) => {
-              const agTxt = `${r.agente_emoji ? r.agente_emoji + ' ' : ''}${escapeHtml(r.agente)}`;
-              const monTx = `${r.moneda_emoji ? r.moneda_emoji + ' ' : ''}${escapeHtml(r.moneda)}`;
-              msg += `• ${escapeHtml(r.numero)} – ${agTxt} – ${monTx} ⇒ ${fmt(r.saldo)}\n`;
-            });
-          if (data.pos)
-            msg += `  <i>Subtotal ${escapeHtml(bankCode)} (activo):</i> ${fmt(data.pos)} ${escapeHtml(monCode)}\n`;
-          if (data.neg)
-            msg += `  <i>Subtotal ${escapeHtml(bankCode)} (deuda):</i> ${fmt(data.neg)} ${escapeHtml(monCode)}\n`;
+async function showAgentList(ctx) {
+  const agents = Object.values(ctx.wizard.state.data.byAgent)
+    .filter((a) => a.totalUsd !== 0)
+    .sort((a, b) => a.nombre.localeCompare(b.nombre));
+  const kb = agents.map((a) => [
+    Markup.button.callback(
+      `${a.emoji ? a.emoji + ' ' : ''}${escapeHtml(a.nombre)}`,
+      `AG_${a.id}`
+    ),
+  ]);
+  kb.push(buildBackExitRow());
+  const text = '👤 <b>Agentes</b>\nSelecciona un agente:';
+  await editIfChanged(ctx, ctx.chat.id, ctx.wizard.state.msgId, text, {
+    parse_mode: 'HTML',
+    reply_markup: { inline_keyboard: kb },
+  });
+  ctx.wizard.state.route = { view: 'AGENT_LIST' };
+}
+
+function buildAgentPages(agent) {
+  const pages = [];
+  Object.values(agent.perMon)
+    .filter((m) => m.total !== 0)
+    .forEach((m) => {
+      let msg = `👤 <b>${agent.emoji ? agent.emoji + ' ' : ''}${escapeHtml(
+        agent.nombre
+      )}</b>\n`;
+      msg += `${m.emoji} <b>${escapeHtml(m.code)}</b>\n`;
+      m.tarjetas
+        .filter((t) => t.saldo !== 0)
+        .forEach((t) => {
+          msg += `• ${escapeHtml(t.numero)} – ${escapeHtml(
+            t.banco
+          )} ⇒ ${fmt(t.saldo)}\n`;
         });
-      const rateToUsd = fmt(info.rate, 6);
-      const rateFromUsd = fmt(1 / info.rate, 2);
-      const activeUsd = info.totalPos * info.rate;
-      const debtUsd = info.totalNeg * info.rate;
-      const netoUsd = activeUsd + debtUsd;
-      msg += `\n<b>Total activo:</b> ${fmt(info.totalPos)}\n`;
-      if (info.totalNeg) msg += `<b>Total deuda:</b> ${fmt(info.totalNeg)}\n`;
-      msg += `<b>Neto:</b> ${fmt(neto)}\n`;
-      msg += `\n<b>Equivalente activo en USD:</b> ${fmt(activeUsd)}\n`;
-      if (info.totalNeg) msg += `<b>Equivalente deuda en USD:</b> ${fmt(debtUsd)}\n`;
-      msg += `<b>Equivalente neto en USD:</b> ${fmt(netoUsd)}\n`;
-      msg += `\n<i>Tasa usada:</i>\n`;
-      msg += `  • 1 ${escapeHtml(monCode)} = ${rateToUsd} USD\n`;
-      msg += `  • 1 USD ≈ ${rateFromUsd} ${escapeHtml(monCode)}`;
-      blocks.push(msg);
-    }
-    const body = blocks.join('\n\n');
-    const text = body
-      ? `📊 <b>Por moneda y banco</b>\n\n${body}`
-      : 'No hay tarjetas registradas todavía.';
-    return paginate(text);
-  }
-
-  if (view === 'VIEW_AGENT') {
-    const blocks = [];
-    const today = new Date().toLocaleDateString('es-CU', {
-      timeZone: 'America/Havana',
+      msg += `\n<b>Total:</b> ${fmt(m.total)} ${escapeHtml(m.code)}\n`;
+      msg += `<b>Equiv. USD:</b> ${fmt(m.total * m.rate)}\n`;
+      pages.push(msg);
     });
-    for (const [agName, agData] of Object.entries(agentMap)) {
-      if (agData.totalUsd === 0) continue;
-      let agMsg = `📅 <b>${escapeHtml(today)}</b>\n`;
-      agMsg += `👤 <b>Resumen de ${agData.emoji ? agData.emoji + ' ' : ''}${escapeHtml(agName)}</b>\n\n`;
-      Object.entries(agData.perMon)
-        .filter(([, m]) => m.total !== 0)
-        .forEach(([monCode, mData]) => {
-          const line =
-            `${mData.emoji} <b>${escapeHtml(monCode)}</b>: ${fmt(mData.total)} ` +
-            `(≈ ${fmt(mData.total * mData.rate)} USD)`;
-          agMsg += line + '\n';
-          mData.filas
-            .filter((f) => f.saldo !== 0)
-            .forEach((r) => {
-              const deuda = r.saldo < 0 ? ' (deuda)' : '';
-              agMsg += `   • ${escapeHtml(r.numero)} ⇒ ${fmt(r.saldo)}${deuda}\n`;
-            });
-          agMsg += '\n';
-        });
-      agMsg += `<b>Total en USD:</b> ${fmt(agData.totalUsd)}`;
-      blocks.push(agMsg);
-    }
-    const body = blocks.join('\n\n');
-    const text = body
-      ? `👤 <b>Por agente</b>\n\n${body}`
-      : 'No hay tarjetas registradas todavía.';
-    return paginate(text);
-  }
+  return pages.length ? pages : ['No hay datos.'];
+}
 
-  if (view === 'VIEW_SUM') {
-    let resumen = '🧮 <b>Resumen general en USD</b>\n';
-    Object.entries(bankUsd)
-      .filter(([, usd]) => usd !== 0)
-      .sort(([a], [b]) => a.localeCompare(b))
-      .forEach(([bank, usd]) => {
-        resumen += `• <b>${escapeHtml(bank)}</b>: ${fmt(usd)} USD\n`;
-      });
-    resumen += `\n<b>Total general:</b> ${fmt(globalUsd)} USD`;
-    return paginate(resumen);
-  }
+async function showAgentDetail(ctx, agentId, page = 0) {
+  const agent = ctx.wizard.state.data.byAgent[agentId];
+  const pages = buildAgentPages(agent);
+  const idx = Math.max(0, Math.min(page, pages.length - 1));
+  ctx.wizard.state.pages = pages;
+  ctx.wizard.state.pageIndex = idx;
+  ctx.wizard.state.route = { view: 'AGENT_DETAIL', agentId };
+  const text =
+    pages[idx] + `\n\nPágina ${idx + 1}/${pages.length}`;
+  await editIfChanged(ctx, ctx.chat.id, ctx.wizard.state.msgId, text, {
+    parse_mode: 'HTML',
+    ...buildNavKeyboard(pages.length),
+  });
+}
 
-  return ['Vista no soportada'];
+async function showMonList(ctx) {
+  const mons = Object.values(ctx.wizard.state.data.byMon)
+    .filter((m) => Object.values(m.banks).some((b) => b.pos + b.neg !== 0))
+    .sort((a, b) => a.code.localeCompare(b.code));
+  const kb = mons.map((m) => [
+    Markup.button.callback(
+      `${m.emoji ? m.emoji + ' ' : ''}${escapeHtml(m.code)}`,
+      `MON_${m.code}`
+    ),
+  ]);
+  kb.push(buildBackExitRow());
+  const text = '💱 <b>Monedas</b>\nSelecciona una moneda:';
+  await editIfChanged(ctx, ctx.chat.id, ctx.wizard.state.msgId, text, {
+    parse_mode: 'HTML',
+    reply_markup: { inline_keyboard: kb },
+  });
+  ctx.wizard.state.route = { view: 'MON_LIST' };
+}
+
+async function showBankList(ctx, monCode) {
+  const mon = ctx.wizard.state.data.byMon[monCode];
+  const banks = Object.values(mon.banks)
+    .filter((b) => b.pos + b.neg !== 0)
+    .sort((a, b) => a.code.localeCompare(b.code));
+  const kb = banks.map((b) => [
+    Markup.button.callback(
+      `${b.emoji ? b.emoji + ' ' : ''}${escapeHtml(b.code)}`,
+      `BK_${mon.code}_${b.code}`
+    ),
+  ]);
+  kb.push(buildBackExitRow());
+  const text = `${mon.emoji} <b>${escapeHtml(
+    mon.code
+  )}</b>\nSelecciona banco:`;
+  await editIfChanged(ctx, ctx.chat.id, ctx.wizard.state.msgId, text, {
+    parse_mode: 'HTML',
+    reply_markup: { inline_keyboard: kb },
+  });
+  ctx.wizard.state.route = { view: 'MON_BANKS', monCode };
+}
+
+function buildMonBankPages(mon, bank) {
+  let msg = `${mon.emoji} <b>${escapeHtml(mon.code)}</b> - ${bank.emoji} <b>${escapeHtml(
+    bank.code
+  )}</b>\n\n`;
+  bank.tarjetas
+    .filter((t) => t.saldo !== 0)
+    .forEach((t) => {
+      const agTxt = `${t.agente_emoji ? t.agente_emoji + ' ' : ''}${escapeHtml(
+        t.agente
+      )}`;
+      msg += `• ${escapeHtml(t.numero)} – ${agTxt} ⇒ ${fmt(t.saldo)}\n`;
+    });
+  const total = bank.pos + bank.neg;
+  msg += `\n<b>Total activo:</b> ${fmt(bank.pos)} ${escapeHtml(mon.code)}\n`;
+  if (bank.neg)
+    msg += `<b>Total deuda:</b> ${fmt(bank.neg)} ${escapeHtml(mon.code)}\n`;
+  msg += `<b>Neto:</b> ${fmt(total)} ${escapeHtml(mon.code)}\n`;
+  msg += `<b>Equiv. neto USD:</b> ${fmt(total * mon.rate)}\n`;
+  return paginate(msg);
+}
+
+async function showMonBankDetail(ctx, monCode, bankCode, page = 0) {
+  const mon = ctx.wizard.state.data.byMon[monCode];
+  const bank = mon.banks[bankCode];
+  const pages = buildMonBankPages(mon, bank);
+  const idx = Math.max(0, Math.min(page, pages.length - 1));
+  ctx.wizard.state.pages = pages;
+  ctx.wizard.state.pageIndex = idx;
+  ctx.wizard.state.route = { view: 'MON_DETAIL', monCode, bankCode };
+  const text = pages[idx] + `\n\nPágina ${idx + 1}/${pages.length}`;
+  await editIfChanged(ctx, ctx.chat.id, ctx.wizard.state.msgId, text, {
+    parse_mode: 'HTML',
+    ...buildNavKeyboard(pages.length),
+  });
+}
+
+async function showSummary(ctx) {
+  const { bankUsd, globalUsd } = ctx.wizard.state.data;
+  let resumen = '🧮 <b>Resumen general en USD</b>\n';
+  Object.entries(bankUsd)
+    .filter(([, usd]) => usd !== 0)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .forEach(([bank, usd]) => {
+      resumen += `• <b>${escapeHtml(bank)}</b>: ${fmt(usd)} USD\n`;
+    });
+  resumen += `\n<b>Total general:</b> ${fmt(globalUsd)} USD`;
+  const kb = Markup.inlineKeyboard([
+    [Markup.button.callback('👤 Por agente', 'VIEW_AGENT')],
+    [Markup.button.callback('📊 Por moneda y banco', 'VIEW_MON')],
+    buildBackExitRow(),
+  ]);
+  await editIfChanged(ctx, ctx.chat.id, ctx.wizard.state.msgId, resumen, {
+    parse_mode: 'HTML',
+    ...kb,
+  });
+  ctx.wizard.state.route = { view: 'SUMMARY' };
 }
 
 /* ───────── Wizard ───────── */
 const tarjetasAssist = new Scenes.WizardScene(
   'TARJETAS_ASSIST',
-
-  /* Paso 0 – menú inicial */
   async (ctx) => {
-    console.log('[TARJETAS_ASSIST] paso 0: menú inicial');
-    await showMenu(ctx);
+    console.log('[TARJETAS_ASSIST] inicio menú');
+    const kb = Markup.inlineKeyboard([
+      [Markup.button.callback('📊 Por moneda y banco', 'VIEW_MON')],
+      [Markup.button.callback('👤 Por agente', 'VIEW_AGENT')],
+      [Markup.button.callback('🧮 Resumen USD global', 'VIEW_SUM')],
+      [Markup.button.callback('❌ Salir', 'EXIT')],
+    ]);
+    const text = '💳 <b>Tarjetas</b>\nElige la vista deseada:';
+    const msg = await ctx.reply(text, { parse_mode: 'HTML', ...kb });
+    ctx.wizard.state.msgId = msg.message_id;
+    ctx.wizard.state.lastRender = { text, reply_markup: kb.reply_markup };
+    ctx.wizard.state.route = { view: 'MENU' };
     return ctx.wizard.next();
   },
-
-  /* Paso 1 – elegir vista y mostrar página 0 */
   async (ctx) => {
-    console.log('[TARJETAS_ASSIST] paso 1: elegir vista');
-    if (await wantExit(ctx)) return;
-    const choice = ctx.callbackQuery?.data;
-    if (!choice?.startsWith('VIEW_')) return ctx.reply('Usa los botones.');
-    await ctx.answerCbQuery().catch(() => {});
-    const pages = await buildView(choice);
-    ctx.wizard.state.currentView = choice;
-    ctx.wizard.state.pages = pages;
-    ctx.wizard.state.pageIndex = 0;
-    await renderPage(ctx);
-    return ctx.wizard.next();
-  },
-
-  /* Paso 2 – navegación */
-  async (ctx) => {
-    console.log('[TARJETAS_ASSIST] paso 2: navegación');
     if (await wantExit(ctx)) return;
     const data = ctx.callbackQuery?.data;
     if (!data) return;
     await ctx.answerCbQuery().catch(() => {});
-    const pages = ctx.wizard.state.pages || [];
-    let i = ctx.wizard.state.pageIndex || 0;
-    switch (data) {
-      case 'FIRST':
-        i = 0;
-        break;
-      case 'PREV':
-        i = Math.max(0, i - 1);
-        break;
-      case 'NEXT':
-        i = Math.min(pages.length - 1, i + 1);
-        break;
-      case 'LAST':
-        i = pages.length - 1;
-        break;
-      case 'BACK':
-        await showMenu(ctx);
-        delete ctx.wizard.state.pages;
-        delete ctx.wizard.state.pageIndex;
-        delete ctx.wizard.state.currentView;
-        return ctx.wizard.selectStep(1);
-      default:
-        return;
+    const route = ctx.wizard.state.route?.view || 'MENU';
+
+    if (!ctx.wizard.state.data) {
+      ctx.wizard.state.data = await loadData();
     }
-    ctx.wizard.state.pageIndex = i;
-    await renderPage(ctx);
+
+    switch (route) {
+      case 'MENU':
+        if (data === 'VIEW_AGENT') return showAgentList(ctx);
+        if (data === 'VIEW_MON') return showMonList(ctx);
+        if (data === 'VIEW_SUM') return showSummary(ctx);
+        break;
+      case 'AGENT_LIST':
+        if (data === 'BACK') return showMenu(ctx);
+        if (data.startsWith('AG_')) {
+          const id = data.split('_')[1];
+          console.log('[TARJETAS_ASSIST] cambio a vista AGENTE detalle', id);
+          return showAgentDetail(ctx, id, 0);
+        }
+        break;
+      case 'AGENT_DETAIL':
+        if (data === 'BACK') return showAgentList(ctx);
+        {
+          const pages = ctx.wizard.state.pages || [];
+          let i = ctx.wizard.state.pageIndex || 0;
+          const last = pages.length - 1;
+          let ni = i;
+          if (data === 'FIRST') ni = 0;
+          else if (data === 'PREV') ni = Math.max(0, i - 1);
+          else if (data === 'NEXT') ni = Math.min(last, i + 1);
+          else if (data === 'LAST') ni = last;
+          if (ni === i) return ctx.answerCbQuery('Sin más páginas').catch(() => {});
+          ctx.wizard.state.pageIndex = ni;
+          const txt =
+            pages[ni] + `\n\nPágina ${ni + 1}/${pages.length}`;
+          await editIfChanged(ctx, ctx.chat.id, ctx.wizard.state.msgId, txt, {
+            parse_mode: 'HTML',
+            ...buildNavKeyboard(pages.length),
+          });
+        }
+        break;
+      case 'MON_LIST':
+        if (data === 'BACK') return showMenu(ctx);
+        if (data.startsWith('MON_')) {
+          const mon = data.split('_')[1];
+          console.log('[TARJETAS_ASSIST] cambio a vista MONEDA', mon);
+          return showBankList(ctx, mon);
+        }
+        break;
+      case 'MON_BANKS':
+        if (data === 'BACK') return showMonList(ctx);
+        if (data.startsWith('BK_')) {
+          const [, mon, bank] = data.split('_');
+          console.log(
+            '[TARJETAS_ASSIST] cambio a vista MONEDA+BANK detalle',
+            mon,
+            bank
+          );
+          return showMonBankDetail(ctx, mon, bank, 0);
+        }
+        break;
+      case 'MON_DETAIL':
+        if (data === 'BACK') {
+          const { monCode } = ctx.wizard.state.route;
+          return showBankList(ctx, monCode);
+        }
+        {
+          const pages = ctx.wizard.state.pages || [];
+          let i = ctx.wizard.state.pageIndex || 0;
+          const last = pages.length - 1;
+          let ni = i;
+          if (data === 'FIRST') ni = 0;
+          else if (data === 'PREV') ni = Math.max(0, i - 1);
+          else if (data === 'NEXT') ni = Math.min(last, i + 1);
+          else if (data === 'LAST') ni = last;
+          if (ni === i) return ctx.answerCbQuery('Sin más páginas').catch(() => {});
+          ctx.wizard.state.pageIndex = ni;
+          const txt =
+            pages[ni] + `\n\nPágina ${ni + 1}/${pages.length}`;
+          await editIfChanged(ctx, ctx.chat.id, ctx.wizard.state.msgId, txt, {
+            parse_mode: 'HTML',
+            ...buildNavKeyboard(pages.length),
+          });
+        }
+        break;
+      case 'SUMMARY':
+        if (data === 'BACK') return showMenu(ctx);
+        if (data === 'VIEW_AGENT') return showAgentList(ctx);
+        if (data === 'VIEW_MON') return showMonList(ctx);
+        break;
+      default:
+        break;
+    }
   }
 );
 

--- a/helpers/ui.js
+++ b/helpers/ui.js
@@ -1,0 +1,51 @@
+// helpers/ui.js
+//
+// Funciones reutilizables para asistentes tipo wizard.
+// Incluye:
+//   - editIfChanged: evita el error 400 "message is not modified" comparando
+//     el texto y el teclado anterior antes de editar.
+//   - buildNavKeyboard: genera botones de navegación estándar.
+//   - buildBackExitRow: fila con botones "Volver" y "Salir".
+//
+// Todos los mensajes usan parse_mode HTML; se asume que los textos dinámicos
+// ya vienen saneados con escapeHtml.
+const { Markup } = require('telegraf');
+
+// Deep compare simplificado para reply_markup
+function sameMarkup(a = {}, b = {}) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+async function editIfChanged(ctx, chatId, messageId, text, extra = {}, useCaption = false) {
+  const last = ctx.wizard?.state?.lastRender || {};
+  const markup = extra.reply_markup || null;
+  if (last.text === text && sameMarkup(last.reply_markup, markup)) {
+    return false; // sin cambios
+  }
+  const method = useCaption ? 'editMessageCaption' : 'editMessageText';
+  await ctx.telegram[method](chatId, messageId, undefined, text, extra);
+  ctx.wizard.state.lastRender = { text, reply_markup: markup };
+  return true;
+}
+
+function buildBackExitRow() {
+  return [
+    Markup.button.callback('🔙 Volver', 'BACK'),
+    Markup.button.callback('❌ Salir', 'EXIT'),
+  ];
+}
+
+function buildNavKeyboard(totalPages) {
+  const rows = [
+    [
+      Markup.button.callback('⏮️', 'FIRST'),
+      Markup.button.callback('◀️', 'PREV'),
+      Markup.button.callback('▶️', 'NEXT'),
+      Markup.button.callback('⏭️', 'LAST'),
+    ],
+    buildBackExitRow(),
+  ];
+  return Markup.inlineKeyboard(rows);
+}
+
+module.exports = { editIfChanged, buildNavKeyboard, buildBackExitRow };


### PR DESCRIPTION
## Summary
- refactor tarjetas assistant with hierarchical views and safe message editing
- extend monitor assistant with combinable period/agent/bank filters
- add shared wizard UI helpers

## Testing
- `node -e "require('./commands/tarjetas_assist')"`
- `node -e "require('./commands/monitor_assist')"`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688dd47ca60c832d997e5e6161c1984c