### PR TITLE
feat: add view all option to card assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - Formato HTML consistente con sanitización y edición inteligente para evitar errores.
 - Menú principal de tarjetas en formato de lista; los agentes siempre se muestran de dos en dos.
 - Teclados inline de dos botones por fila y navegación con paginación reutilizable.
-- `/tarjetas` permite hacer drill-down por agente o por combinación moneda+banco sin mezclar entidades.
+- `/tarjetas` permite hacer drill-down por agente o por combinación moneda+banco, o bien ver todas las tarjetas sin filtro.
 - `/monitor` combina filtros de periodo, moneda, agente y banco, con opción de "Ver en privado" y botones "Todos" para ver resúmenes globales.
 
 ## 🚀 Instalación
@@ -177,6 +177,7 @@ Inicia el asistente para crear o actualizar una tarjeta. Permite elegir agente, 
 
 ### 📇 <span style="color:#9b59b6;">/tarjetas</span>
 Lista todas las tarjetas con sus saldos actuales, agrupadas por moneda y banco.
+Incluye un botón <strong>Ver todas</strong> para mostrar toda la información sin aplicar filtros.
 
 **Ejemplo:**
 ```text


### PR DESCRIPTION
## Summary
- add new **Ver todas** button to card assistant menus
- implement aggregated view to list every card without filters
- document the new feature in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688df0957ec8832d9095bddfd8bf439b