### PR TITLE
feat(extracto): add entry and exit totals to header

### DIFF
--- a/commands/extracto_assist.js
+++ b/commands/extracto_assist.js
@@ -275,10 +275,13 @@ async function showExtract(ctx, period) {
     )
   ).rows;
   let body = '';
+  let totalIn = 0;
+  let totalOut = 0;
   for (const mv of movimientos) {
     const f = new Date(mv.creado_en);
     body += `${f.toLocaleString()} — ${escapeHtml(mv.descripcion || '')} `;
     const imp = parseFloat(mv.importe) || 0;
+    if (imp >= 0) totalIn += imp; else totalOut += -imp;
     const sign = imp >= 0 ? '+' : '-';
     body += `${sign}${fmt(Math.abs(imp))} → ${fmt(mv.saldo_nuevo)}\n`;
   }
@@ -291,7 +294,9 @@ async function showExtract(ctx, period) {
       : tarjeta.banco
       ? `🏦 Banco: <b>${escapeHtml(tarjeta.banco)}</b>\n`
       : '') +
-    `Periodo: <b>${r.label}</b>\n\n`;
+    `Periodo: <b>${r.label}</b>\n` +
+    `↗️ Entradas: <b>${fmt(totalIn)}</b>\n` +
+    `↘️ Salidas: <b>${fmt(totalOut)}</b>\n\n`;
   const pages = paginate(header + body);
   ctx.wizard.state.pages = pages;
   ctx.wizard.state.pageIndex = 0;


### PR DESCRIPTION
## Summary
- show total incoming and outgoing amounts in extract summaries

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688e421bea40832dba06f6615802b46e