### PR TITLE
feat: interactive extract filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Resultados del mes actual vs anterior...
 ```
 
 ### 📄 <span style="color:#34495e;">/extracto</span>
-Muestra un extracto bancario por tarjeta basado en los movimientos registrados. Permite filtrar por agente o banco y elegir el periodo (día, semana o mes).
+Genera un extracto bancario con filtros combinables. Puedes elegir el agente y luego filtrar por moneda, banco o tarjeta, con botones de **Todos** para obtener resúmenes globales. El reporte indica entradas, salidas, saldo actual y su equivalente en USD para cada moneda.
 
 **Ejemplo:**
 ```text


### PR DESCRIPTION
## Summary
- redesign extract assistant with monitor-like filters
- allow selecting agents, currencies, banks, cards or viewing all
- show totals with USD equivalents for each currency

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688e5fe77510832dbab7e7b56962faa9