### PR TITLE
Centralize entity filters and normalize queries

### DIFF
--- a/helpers/filters.js
+++ b/helpers/filters.js
@@ -1,0 +1,56 @@
+// helpers/filters.js
+// -----------------------------------------------------------------------------
+// Utilidades para construir filtros parametrizados por entidad (agente, banco,
+// moneda, etc.).  Normaliza textos con unaccent+lower si la extensión está
+// disponible; de lo contrario, recurre a lower() y emite una advertencia.
+// Detecta si el valor provisto es un ID numérico para usar comparaciones por
+// clave foránea en lugar de LIKE sobre nombres.
+// -----------------------------------------------------------------------------
+
+const { query } = require('../psql/db');
+
+let hasUnaccent = null;
+
+async function checkUnaccent() {
+  if (hasUnaccent !== null) return;
+  try {
+    await query("SELECT 1 FROM pg_extension WHERE extname='unaccent'");
+    hasUnaccent = true;
+  } catch (err) {
+    hasUnaccent = false;
+    console.warn(
+      '[filters] Extensión unaccent no disponible. Ejecuta "CREATE EXTENSION unaccent;" para obtener comparaciones sin acentos.'
+    );
+  }
+}
+
+function normExpr(expr) {
+  return hasUnaccent ? `unaccent(lower(${expr}))` : `lower(${expr})`;
+}
+
+/**
+ * Construye una condición SQL parametrizada para una entidad.
+ * @param {string} alias       Alias de la tabla en la consulta.
+ * @param {string|number} val  Valor de filtro (ID numérico o nombre).
+ * @param {Array} params       Arreglo donde se acumulan los parámetros.
+ * @param {string} idField     Columna de ID (por defecto 'id').
+ * @param {string[]} nameFields Columnas de texto a comparar si val no es numérico.
+ * @returns {Promise<string|null>}  Condición lista para el WHERE o null si no aplica.
+ */
+async function buildEntityFilter(alias, val, params, idField = 'id', nameFields = ['nombre']) {
+  if (!val) return null;
+  await checkUnaccent();
+  const value = String(val).trim();
+  if (/^\d+$/.test(value)) {
+    params.push(parseInt(value, 10));
+    return `${alias}.${idField} = $${params.length}`;
+  }
+  params.push(`%${value}%`);
+  const idx = params.length;
+  const parts = nameFields.map(
+    (f) => `${normExpr(`${alias}.${f}`)} LIKE ${normExpr(`$${idx}`)}`
+  );
+  return `(${parts.join(' OR ')})`;
+}
+
+module.exports = { buildEntityFilter, checkUnaccent, normExpr };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node tests/filterConsistency.test.js"
   },
   "author": "",
   "license": "ISC",

--- a/tests/filterConsistency.test.js
+++ b/tests/filterConsistency.test.js
@@ -1,0 +1,49 @@
+const assert = require('assert');
+const { query } = require('../psql/db');
+const { buildEntityFilter } = require('../helpers/filters');
+
+async function testEntity(table, alias, id, name, idField = 'id', nameFields = ['nombre']) {
+  let params = [];
+  const clauseId = await buildEntityFilter(alias, String(id), params, idField, nameFields);
+  const byId = await query(`SELECT ${idField} FROM ${table} ${alias} WHERE ${clauseId}`, params);
+  params = [];
+  const clauseName = await buildEntityFilter(alias, name, params, idField, nameFields);
+  const byName = await query(`SELECT ${idField} FROM ${table} ${alias} WHERE ${clauseName}`, params);
+  assert.strictEqual(byId.rows[0][idField], byName.rows[0][idField]);
+}
+
+async function run() {
+  const ag = await query('SELECT id,nombre FROM agente LIMIT 1');
+  if (ag.rows.length) {
+    const { id, nombre } = ag.rows[0];
+    await testEntity('agente', 'ag', id, nombre);
+    console.log('✓ agente por id/nombre');
+  } else {
+    console.warn('⚠️ sin agentes, prueba omitida');
+  }
+
+  const bn = await query('SELECT id,codigo FROM banco LIMIT 1');
+  if (bn.rows.length) {
+    const { id, codigo } = bn.rows[0];
+    await testEntity('banco', 'b', id, codigo, 'id', ['codigo', 'nombre']);
+    console.log('✓ banco por id/código');
+  } else {
+    console.warn('⚠️ sin bancos, prueba omitida');
+  }
+
+  const mn = await query('SELECT id,codigo FROM moneda LIMIT 1');
+  if (mn.rows.length) {
+    const { id, codigo } = mn.rows[0];
+    await testEntity('moneda', 'm', id, codigo, 'id', ['codigo', 'nombre']);
+    console.log('✓ moneda por id/código');
+  } else {
+    console.warn('⚠️ sin monedas, prueba omitida');
+  }
+}
+
+run()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error('Test failed', err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- add reusable SQL filter builder with unaccent fallback
- apply numeric-or-text filters in /monitor and extracto assistant
- log empty-filter diagnostics and add basic consistency tests
- streamline extracto assistant with smarter pagination and detailed logs

## Testing
- `npm test` *(fails: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_688fc19016b4832daad78134eac402b9