### PR TITLE
feat: add reporting helpers and session summaries

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@ const { Scenes, session } = require('telegraf');
 // Migrated responses to HTML parse mode; escapeHtml centralizes sanitization
 // to prevent markup breakage when interpolating dynamic content.
 const { escapeHtml } = require('./helpers/format');
+const { ownerIds } = require('./config');
 
 /* ───────── 1. Bot base ───────── */
 const bot = require('./bot');
@@ -68,7 +69,7 @@ const verificarAcceso = async (ctx, next) => {
   }
 
   const uid = ctx.from?.id?.toString() || '0';
-  const esOwner  = uid === process.env.OWNER_ID;
+  const esOwner  = ownerIds.includes(Number(uid));
   const permitido = esOwner || (await usuarioExiste(uid));
 
   console.log(`🛂 acceso uid:${uid} permitido:${permitido}`);

--- a/config.js
+++ b/config.js
@@ -1,0 +1,12 @@
+const ownerIds = (process.env.OWNER_ID || '')
+  .split(/[,\s]+/)
+  .filter(Boolean)
+  .map((id) => parseInt(id, 10))
+  .filter((n) => !isNaN(n));
+
+const statsChatId = process.env.STATS_CHAT_ID ? parseInt(process.env.STATS_CHAT_ID, 10) : null;
+if (!statsChatId) {
+  console.warn('[config] STATS_CHAT_ID no definido; se omitirá el reenvío de estadísticas.');
+}
+
+module.exports = { ownerIds, statsChatId };

--- a/helpers/format.js
+++ b/helpers/format.js
@@ -15,4 +15,9 @@ function escapeHtml(text) {
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
 }
-module.exports = { escapeHtml };
+
+function fmtMoney(n) {
+  return Number.parseFloat(n || 0).toFixed(2);
+}
+
+module.exports = { escapeHtml, fmtMoney };

--- a/helpers/period.js
+++ b/helpers/period.js
@@ -1,0 +1,5 @@
+function getDefaultPeriod() {
+  return 'ano';
+}
+
+module.exports = { getDefaultPeriod };

--- a/helpers/reportSender.js
+++ b/helpers/reportSender.js
@@ -1,0 +1,25 @@
+const { statsChatId, ownerIds } = require('../config');
+
+async function sendAndLog(ctx, html, extra = {}) {
+  const msg = await ctx.reply(html, { parse_mode: 'HTML', ...extra });
+  if (statsChatId) {
+    try {
+      await ctx.telegram.sendMessage(statsChatId, html, { parse_mode: 'HTML' });
+    } catch (err) {
+      console.error('[reportSender] error enviando a STATS_CHAT_ID', err);
+    }
+  }
+  return msg;
+}
+
+async function notifyOwners(ctx, html, extra = {}) {
+  for (const id of ownerIds) {
+    try {
+      await ctx.telegram.sendMessage(id, html, { parse_mode: 'HTML', ...extra });
+    } catch (err) {
+      console.error('[reportSender] error notificando a owner', id, err);
+    }
+  }
+}
+
+module.exports = { sendAndLog, notifyOwners };

--- a/helpers/sessionSummary.js
+++ b/helpers/sessionSummary.js
@@ -1,0 +1,81 @@
+const { sendAndLog, notifyOwners } = require('./reportSender');
+const { fmtMoney } = require('./format');
+const db = require('../psql/db.js');
+const { query } = db;
+
+const changes = new Map(); // agentId => Map(tarjetaId => {antes, despues})
+
+function recordChange(agentId, tarjetaId, saldoAntes, saldoDespues) {
+  if (!changes.has(agentId)) changes.set(agentId, new Map());
+  changes.get(agentId).set(tarjetaId, { antes: saldoAntes, despues: saldoDespues });
+}
+
+function pad(str, len) {
+  str = String(str);
+  return str.padEnd(len).slice(0, len);
+}
+
+async function flushOnExit(ctx) {
+  if (!changes.size) return;
+  try {
+    const agentSummaries = [];
+    for (const [agId, cards] of changes.entries()) {
+      const agRes = await query('SELECT nombre FROM agente WHERE id=$1', [agId]);
+      const agName = agRes.rows[0]?.nombre || `#${agId}`;
+      const cardRes = await query(
+        `SELECT t.id, t.numero,
+                COALESCE(mv.saldo_nuevo,0) AS saldo
+           FROM tarjeta t
+           LEFT JOIN LATERAL (
+             SELECT saldo_nuevo
+               FROM movimiento
+              WHERE tarjeta_id = t.id
+              ORDER BY creado_en DESC
+              LIMIT 1
+           ) mv ON true
+          WHERE t.agente_id = $1
+          ORDER BY t.numero`,
+        [agId]
+      );
+      const lines = cardRes.rows.map((c) => {
+        const change = cards.get(c.id);
+        const antes = change ? change.antes : parseFloat(c.saldo) || 0;
+        const despues = change ? change.despues : parseFloat(c.saldo) || 0;
+        const delta = despues - antes;
+        const emoji = delta > 0 ? '📈' : delta < 0 ? '📉' : '➖';
+        const deltaStr = `${delta >= 0 ? '+' : ''}${fmtMoney(delta)}`;
+        return `${pad(c.numero, 8)} <code>${fmtMoney(antes)}</code> → <code>${fmtMoney(despues)}</code>   <code>${deltaStr}</code> ${emoji}`;
+      });
+      const head = `📝 Resumen de ajustes – ${new Date()
+        .toLocaleString('es-ES', {
+          day: '2-digit',
+          month: '2-digit',
+          year: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit',
+        })}\n👤 Agente: ${agName}\n\nTarjeta   Saldo anterior → Saldo actual   Δ\n`;
+      const body = head + lines.join('\n');
+      await sendAndLog(ctx, body.trim());
+      agentSummaries.push({ agId, agName, changed: cards.size, total: cardRes.rows.length });
+    }
+    if (agentSummaries.length) {
+      const totalChanged = agentSummaries.reduce((a, b) => a + b.changed, 0);
+      const totalCards = agentSummaries.reduce((a, b) => a + b.total, 0);
+      const names = agentSummaries.map((a) => a.agName).join(', ');
+      const summary = `✅ Ajustes completados por <@${ctx.from?.username || ctx.from?.id}> – ${new Date()
+        .toLocaleString('es-ES', {
+          day: '2-digit',
+          month: '2-digit',
+          year: 'numeric',
+          hour: '2-digit',
+          minute: '2-digit',
+        })}\nAgentes afectados: ${names} (${totalChanged} de ${totalCards} tarjetas cambiadas)`;
+      await notifyOwners(ctx, summary);
+    }
+  } catch (err) {
+    console.error('[sessionSummary] error al enviar resumen', err);
+  }
+  changes.clear();
+}
+
+module.exports = { recordChange, flushOnExit };


### PR DESCRIPTION
## Summary
- centralize money formatting and owner configuration
- add helpers for report forwarding and session summaries
- extend monitor, extracto and saldo flows with save options and logging

## Testing
- `npm test` *(fails: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_688fd3143580832d89fe6caa8377c261