### PR TITLE
feat: mejorar formato de extractos y reportes

### DIFF
--- a/helpers/reportSender.js
+++ b/helpers/reportSender.js
@@ -1,16 +1,5 @@
 const { statsChatId, ownerIds } = require('../config');
-
-async function sendAndLog(ctx, html, extra = {}) {
-  const msg = await ctx.reply(html, { parse_mode: 'HTML', ...extra });
-  if (statsChatId) {
-    try {
-      await ctx.telegram.sendMessage(statsChatId, html, { parse_mode: 'HTML' });
-    } catch (err) {
-      console.error('[reportSender] error enviando a STATS_CHAT_ID', err);
-    }
-  }
-  return msg;
-}
+const { escapeHtml } = require('./format');
 
 async function notifyOwners(ctx, html, extra = {}) {
   for (const id of ownerIds) {
@@ -20,6 +9,32 @@ async function notifyOwners(ctx, html, extra = {}) {
       console.error('[reportSender] error notificando a owner', id, err);
     }
   }
+}
+
+async function sendAndLog(ctx, html, extra = {}) {
+  if (!html || !html.trim()) return null;
+  const safe = html.trim();
+  let msg = null;
+  try {
+    msg = await ctx.reply(safe, { parse_mode: 'HTML', ...extra });
+  } catch (err) {
+    console.error('[reportSender] error ctx.reply', err);
+    await notifyOwners(ctx, `❗️ Error enviando reporte: ${escapeHtml(err.message)}`);
+    return null;
+  }
+  const chatId = String(statsChatId || '').trim();
+  if (chatId) {
+    try {
+      await ctx.telegram.sendMessage(chatId, safe, { parse_mode: 'HTML' });
+    } catch (err) {
+      console.error('[reportSender] error enviando a STATS_CHAT_ID', err);
+      await notifyOwners(
+        ctx,
+        `⚠️ No se pudo enviar a STATS_CHAT_ID (${escapeHtml(err.message)})`,
+      );
+    }
+  }
+  return msg;
 }
 
 module.exports = { sendAndLog, notifyOwners };


### PR DESCRIPTION
## Summary
- format extract reports grouped by card/bank with subtotals
- avoid spamming and fix 'otro extracto' callback handling
- strengthen session summaries and stats sender with error checks

## Testing
- `npm test` *(fails: connect ECONNREFUSED)*


------
https://chatgpt.com/codex/tasks/task_e_688fdb6e8b40832d9d97a3dff705202f