### PR TITLE
feat: enrich session summaries with actor context

### DIFF
--- a/commands/extracto_assist.js
+++ b/commands/extracto_assist.js
@@ -56,10 +56,10 @@ function smartPaginate(text) {
 async function wantExit(ctx) {
   if (ctx.callbackQuery?.data === 'EXIT') {
     await ctx.answerCbQuery().catch(() => {});
-    await ctx.reply('❌ Operación cancelada.', { parse_mode: 'HTML' });
     console.log('[extracto] cancelado por el usuario');
     await flushOnExit(ctx);
     if (ctx.scene?.current) await ctx.scene.leave();
+    await ctx.reply('❌ Operación cancelada.', { parse_mode: 'HTML' });
     return true;
   }
   return false;

--- a/commands/monitor_assist.js
+++ b/commands/monitor_assist.js
@@ -34,9 +34,9 @@ const { runMonitor } = require('./monitor');
 async function wantExit(ctx) {
   if (ctx.callbackQuery?.data === 'EXIT') {
     await ctx.answerCbQuery().catch(() => {});
-    await ctx.reply('❌ Operación cancelada.');
     await flushOnExit(ctx);
     if (ctx.scene?.current) await ctx.scene.leave();
+    await ctx.reply('❌ Operación cancelada.');
     return true;
   }
   return false;

--- a/config.js
+++ b/config.js
@@ -9,4 +9,13 @@ if (!statsChatId) {
   console.warn('[config] STATS_CHAT_ID no definido; se omitirá el reenvío de estadísticas.');
 }
 
-module.exports = { ownerIds, statsChatId };
+const comercialesGroupId = process.env.ID_GROUP_COMERCIALES
+  ? parseInt(process.env.ID_GROUP_COMERCIALES, 10)
+  : null;
+if (!comercialesGroupId) {
+  console.warn(
+    '[config] ID_GROUP_COMERCIALES no definido; se omitirá el reenvío al grupo de comerciales.',
+  );
+}
+
+module.exports = { ownerIds, statsChatId, comercialesGroupId };


### PR DESCRIPTION
## Summary
- add optional commercial group forwarding via `ID_GROUP_COMERCIALES`
- enhance session summaries with actor metadata and per-agent card details
- ensure monitor/extracto wizards flush summaries before signaling cancellation

## Testing
- `npm test` *(fails: connect ECONNREFUSED)*


------
https://chatgpt.com/codex/tasks/task_e_688fee07dd90832d879497936ef99470