### PR TITLE
Add test runner script and database seeds

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function diagnostics() {
+  echo "===== Diagnostics ====="
+  echo "\n--- PostgreSQL databases ---"
+  psql -c '\l' || true
+  echo "\n--- .env.test ---"
+  if [ -f .env.test ]; then
+    sed -E 's/(postgresql:\/\/[^:]+:)[^@]+/\1***@/' .env.test
+  fi
+  echo "\n--- Jest logs (last 30 lines) ---"
+  if [ -f jest.log ]; then
+    tail -n 30 jest.log
+  fi
+}
+
+trap 'status=$?; diagnostics; exit $status' ERR
+
+# 1. Verify PostgreSQL
+if ! command -v psql >/dev/null 2>&1; then
+  echo "psql not found. Please install PostgreSQL." >&2
+  exit 1
+fi
+
+if ! pg_isready >/dev/null 2>&1; then
+  echo "Attempting to start PostgreSQL..."
+  (service postgresql start || sudo service postgresql start || pg_ctl -D "$PGDATA" start || true) >/dev/null 2>&1 || true
+fi
+
+# 2. Ensure ADMIN_DATABASE_URL
+export ADMIN_DATABASE_URL="${ADMIN_DATABASE_URL:-postgresql://postgres:admin@localhost:5432/postgres}"
+
+# 3. Install deps
+npm ci
+
+# 4. Pretest
+npm run pretest
+
+# 5. Tests
+npm test -- --runInBand --detectOpenHandles 2>&1 | tee jest.log
+

--- a/tests/filterConsistency.test.js
+++ b/tests/filterConsistency.test.js
@@ -2,6 +2,7 @@
 require('dotenv').config({ path: './.env.test' });
 const { query } = require('../psql/db');
 const { buildEntityFilter } = require('../helpers/filters');
+const seedMinimal = require('./seedMinimal');
 
 async function testEntity(table, alias, id, name, idField = 'id', nameFields = ['nombre']) {
   let params = [];
@@ -14,6 +15,10 @@ async function testEntity(table, alias, id, name, idField = 'id', nameFields = [
 }
 
 describe('consistencia de filtros', () => {
+  beforeAll(async () => {
+    await seedMinimal();
+  });
+
   it('agente por id/nombre', async () => {
     const ag = await query('SELECT id,nombre FROM agente LIMIT 1');
     if (!ag.rows.length) return;
@@ -35,3 +40,4 @@ describe('consistencia de filtros', () => {
     await testEntity('moneda', 'm', id, codigo, 'id', ['codigo', 'nombre']);
   });
 });
+

--- a/tests/seedMinimal.js
+++ b/tests/seedMinimal.js
@@ -1,0 +1,8 @@
+const { readFileSync } = require('fs');
+const { query } = require('../psql/db');
+
+module.exports = async function seedMinimal() {
+  const sql = readFileSync(__dirname + '/seedMinimal.sql', 'utf8');
+  await query(sql);
+};
+

--- a/tests/seedMinimal.sql
+++ b/tests/seedMinimal.sql
@@ -1,0 +1,5 @@
+-- Minimal seed data for tests
+INSERT INTO agente (id, nombre) VALUES (1, 'Agente Fake') ON CONFLICT (id) DO NOTHING;
+INSERT INTO banco (id, codigo, nombre) VALUES (1, 'FL', 'Fake Bank') ON CONFLICT (id) DO NOTHING;
+INSERT INTO moneda (id, codigo, nombre) VALUES (1, 'FL', 'Fake') ON CONFLICT (id) DO NOTHING;
+


### PR DESCRIPTION
## Summary
- Add run-tests.sh script to initialize PostgreSQL, install deps, and run tests with diagnostics
- Add minimal SQL seeds and helper to populate required tables
- Seed database before filterConsistency tests for reliable results

## Testing
- `./run-tests.sh` *(fails: password authentication failed for user "postgres")*

------
https://chatgpt.com/codex/tasks/task_e_689083213698832d97a845cc9051b2b5