### PR TITLE
Ensure idempotent test database setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS
+
+## Pruebas
+- Ejecuta `npm test` para correr la suite. Esto instala y prepara PostgreSQL automáticamente.
+
+## Salud de la base
+- Para verificar la base local usa:
+  ```bash
+  PGPASSWORD=123456789 psql -h localhost -U wallet -d wallet_test -c 'SELECT 1';
+  ```
+- Si el contenedor se reinicia o necesitas recrear todo, ejecuta:
+  ```bash
+  node scripts/ensureTestDb.js
+  ```
+  Exporta `ADMIN_DATABASE_URL` si deseas apuntar a un servidor externo persistente.

--- a/psql/seedMinimal.js
+++ b/psql/seedMinimal.js
@@ -1,0 +1,21 @@
+// psql/seedMinimal.js
+// Semillas mínimas para pruebas. Inserta un registro por tabla clave
+// usando ON CONFLICT para que sea idempotente.
+
+const { query } = require('./db');
+
+const seedMinimal = async () => {
+  await query(
+    "INSERT INTO moneda (codigo, nombre, tasa_usd, emoji) VALUES ('USD','Dólar',1,'$') ON CONFLICT (codigo) DO NOTHING;"
+  );
+  await query(
+    "INSERT INTO banco (codigo, nombre, emoji) VALUES ('default','Banco Default','🏦') ON CONFLICT (codigo) DO NOTHING;"
+  );
+  await query(
+    "INSERT INTO agente (nombre, emoji) VALUES ('agente_demo','👤') ON CONFLICT (nombre) DO NOTHING;"
+  );
+  console.log('🌱 semillas mínimas aplicadas');
+};
+
+module.exports = seedMinimal;
+

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,6 +1,6 @@
 // tests/setup.js
 const path = require('path');
-require('dotenv').config({ path: path.resolve(__dirname, '../.env.test') });
+require('dotenv').config({ path: path.resolve(__dirname, '../.env.test'), override: true });
 
 // Asegura DB de test y esquema completo
 const { pool } = require('../psql/db');


### PR DESCRIPTION
## Summary
- Make test DB setup script fully idempotent: install/start PostgreSQL, set superuser password, create role and db, run migrations, seed data and write `.env.test`.
- Add minimal seed helper and clarify test setup to override environment variables.
- Provide AGENTS instructions for running tests and checking DB health.

## Testing
- `npm test`
- `PGPASSWORD=123456789 psql -h localhost -U wallet -d wallet_test -c 'SELECT 1 as ok;'`


------
https://chatgpt.com/codex/tasks/task_e_6890879aa54c832da3266c50a0256df0