### PR TITLE
Ensure assistants persist until explicit exit

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@ const { Scenes, session } = require('telegraf');
 // to prevent markup breakage when interpolating dynamic content.
 const { escapeHtml } = require('./helpers/format');
 const { ownerIds } = require('./config');
+const { flushOnExit } = require('./helpers/sessionSummary');
 
 /* ───────── 1. Bot base ───────── */
 const bot = require('./bot');
@@ -56,7 +57,15 @@ async function initDatabase() {
 }
 
 /* ───────── 7. Scenes / Stage ───────── */
-const stage = new Scenes.Stage([tarjetaWizard, saldoWizard, tarjetasAssist, monitorAssist, accesoAssist, extractoAssist], { ttl: 300 });
+const stage = new Scenes.Stage(
+  [tarjetaWizard, saldoWizard, tarjetasAssist, monitorAssist, accesoAssist, extractoAssist],
+  { ttl: 0 },
+);
+stage.hears(/^(salir)$/i, async (ctx) => {
+  await flushOnExit(ctx);
+  if (ctx.scene?.current) await ctx.scene.leave();
+  await ctx.reply('❌ Operación cancelada.');
+});
 bot.use(session());
 bot.use(stage.middleware());
 


### PR DESCRIPTION
## Summary
- keep all wizards active by removing stage TTL
- allow users to type "salir" to cancel any assistant

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c67b607520832d9c33191c00cd1cd9