### PR TITLE
feat: modernize assistant headers

### DIFF
--- a/commands/extracto_assist.js
+++ b/commands/extracto_assist.js
@@ -12,7 +12,7 @@
 
 const { Scenes, Markup } = require('telegraf');
 const moment = require('moment-timezone');
-const { escapeHtml, fmtMoney } = require('../helpers/format');
+const { escapeHtml, fmtMoney, boldHeader } = require('../helpers/format');
 const { getDefaultPeriod } = require('../helpers/period');
 const { sendAndLog } = require('../helpers/reportSender');
 const { flushOnExit } = require('../helpers/sessionSummary');
@@ -160,7 +160,7 @@ async function filterCards(st) {
 /* Visual helpers ---------------------------------------------------------- */
 function header(f) {
   return (
-    '📄 <b>Extracto</b>\n' +
+    `${boldHeader('📄', 'Extracto')}\n` +
     `👤 Agente: <b>${escapeHtml(f.agenteNombre || 'Todos')}</b>\n` +
     `💱 Moneda: <b>${escapeHtml(f.monedaNombre || 'Todas')}</b>\n` +
     `🏦 Banco: <b>${escapeHtml(f.bancoNombre || 'Todos')}</b>\n` +

--- a/commands/monitor.js
+++ b/commands/monitor.js
@@ -7,7 +7,7 @@
 const moment = require('moment-timezone');
 const path = require('path');
 // Migrado a HTML parse mode con sanitización centralizada en escapeHtml.
-const { escapeHtml, fmtMoney } = require('../helpers/format');
+const { escapeHtml, fmtMoney, boldHeader } = require('../helpers/format');
 const { getDefaultPeriod } = require('../helpers/period');
 const { buildEntityFilter } = require('../helpers/filters');
 const { sendLargeMessage } = require('../helpers/sendLargeMessage');
@@ -281,9 +281,14 @@ function buildMessage(moneda, rows, opts, range, historiales) {
   if (opts.banco) filtros.push(`banco=${escapeHtml(opts.banco)}`);
   if (opts.moneda) filtros.push(`moneda=${escapeHtml(opts.moneda)}`);
   if (opts.soloCambio) filtros.push('solo-cambio');
-  const filtStr = filtros.length ? `\nFiltros: ${filtros.join(', ')}\n` : '\n';
+  const filtStr = filtros.length ? `Filtros: ${filtros.join(', ')}\n` : '';
 
-  let msg = `<b>Resumen de ${moneda} para periodo ${range.start.format('DD/MM/YYYY')} – ${range.end.clone().subtract(1, 'second').format('DD/MM/YYYY')}</b>${filtStr}`;
+  let msg =
+    `${boldHeader('📊', 'Monitor')}\n` +
+    `Moneda: <b>${escapeHtml(moneda)}</b>\n` +
+    `Periodo: <b>${range.start.format('DD/MM/YYYY')} – ${range.end.clone().subtract(1, 'second').format('DD/MM/YYYY')}</b>\n` +
+    filtStr +
+    `\n`;
   const deltaPer   = totalFinPer - totalIniPer;
   const emojiPer   = deltaPer > 0 ? '📈' : deltaPer < 0 ? '📉' : '➖';
   msg +=

--- a/commands/monitor_assist.js
+++ b/commands/monitor_assist.js
@@ -20,7 +20,7 @@
 
 const { Scenes, Markup } = require('telegraf');
 const moment = require('moment');
-const { escapeHtml } = require('../helpers/format');
+const { escapeHtml, boldHeader } = require('../helpers/format');
 const { getDefaultPeriod } = require('../helpers/period');
 const { sendAndLog } = require('../helpers/reportSender');
 const { flushOnExit } = require('../helpers/sessionSummary');
@@ -48,7 +48,7 @@ async function wantExit(ctx) {
 async function showMain(ctx) {
   const f = ctx.wizard.state.filters;
   const text =
-    `📈 <b>Monitor</b>\n` +
+    `${boldHeader('📈', 'Monitor')}\n` +
     `Periodo: <b>${escapeHtml(f.fecha || f.mes || f.period)}</b>\n` +
     `Moneda: <b>${escapeHtml(f.monedaNombre || 'Todas')}</b>\n` +
     `Agente: <b>${escapeHtml(f.agenteNombre || 'Todos')}</b>\n` +

--- a/commands/saldo.js
+++ b/commands/saldo.js
@@ -14,7 +14,7 @@
 // Requiere que las tablas ya existan con las columnas definidas en initWalletSchema.
 
 const { Scenes, Markup } = require('telegraf');
-const { escapeHtml, fmtMoney } = require('../helpers/format');
+const { escapeHtml, fmtMoney, boldHeader } = require('../helpers/format');
 const { sendAndLog } = require('../helpers/reportSender');
 const { recordChange, flushOnExit } = require('../helpers/sessionSummary');
 const pool = require('../psql/db.js');
@@ -77,7 +77,7 @@ async function showAgentes(ctx) {
   }
   kb.push([Markup.button.callback('❌ Cancelar', 'GLOBAL_CANCEL')]);
 
-  const txt = '👥 <b>Seleccione uno de los Agentes disponibles</b>';
+  const txt = `${boldHeader('👥', 'Agentes disponibles')}\nSeleccione uno:`;
   const extra = { parse_mode: 'HTML', ...Markup.inlineKeyboard(kb) };
 
   const msgId = ctx.wizard.state.data?.msgId;
@@ -312,7 +312,9 @@ const saldoWizard = new Scenes.WizardScene(
 
       const emojiDelta = delta > 0 ? '📈' : delta < 0 ? '📉' : '➖';
       const signo = delta > 0 ? 'Aumentó' : delta < 0 ? 'Disminuyó' : 'Sin cambio';
+      const header = `${boldHeader('💰', 'Saldo actualizado')}\n`;
       const txt =
+        header +
         `Saldo anterior: <code>${fmtMoney(saldoAnterior)}</code>\n` +
         `Saldo informado: <code>${fmtMoney(saldoNuevo)}</code>\n` +
         `${emojiDelta} ${signo} <code>${fmtMoney(Math.abs(delta))}</code> ${escapeHtml(tarjeta.moneda)}\n\n` +

--- a/commands/tarjetas.js
+++ b/commands/tarjetas.js
@@ -5,7 +5,7 @@
 // para cada tarjeta el saldo inicial, final y la variación.
 
 const pool = require('../psql/db.js');
-const { escapeHtml } = require('../helpers/format');
+const { escapeHtml, boldHeader } = require('../helpers/format');
 const { sendLargeMessage } = require('../helpers/sendLargeMessage');
 
 /* -------------------------------------------------------------------------- */
@@ -133,7 +133,7 @@ module.exports = (bot) => {
 
       // 3. Construir bloques lógicos
       const blocks = [];
-      let resumen = '💳 <b>Tarjetas</b>\n';
+      let resumen = boldHeader('💳', 'Tarjetas') + '\n';
       resumen += '\n<b>Resumen por moneda</b>\n';
       Object.entries(byMon).forEach(([code, info]) => {
         if (info.ini === 0 && info.fin === 0) return;

--- a/commands/tarjetas_assist.js
+++ b/commands/tarjetas_assist.js
@@ -22,7 +22,7 @@
  */
 
 const { Scenes, Markup } = require('telegraf');
-const { escapeHtml } = require('../helpers/format');
+const { escapeHtml, boldHeader } = require('../helpers/format');
 const { sendLargeMessage } = require('../helpers/sendLargeMessage');
 const { sendAndLog } = require('../helpers/reportSender');
 const {
@@ -348,7 +348,7 @@ async function showAll(ctx) {
 
 async function showSummary(ctx) {
   const { bankUsd, globalUsd } = ctx.wizard.state.data;
-  let resumen = '🧮 <b>Resumen general en USD</b>\n';
+  let resumen = boldHeader('🧮', 'Resumen general en USD') + '\n';
   Object.entries(bankUsd)
     .filter(([, usd]) => usd !== 0)
     .sort(([a], [b]) => a.localeCompare(b))
@@ -383,7 +383,7 @@ const tarjetasAssist = new Scenes.WizardScene(
       Markup.button.callback('❌ Salir', 'EXIT'),
     ];
     const kb = Markup.inlineKeyboard(buttons.map((b) => [b]));
-    const text = '💳 <b>Tarjetas</b>\nElige la vista deseada:';
+    const text = `${boldHeader('💳', 'Tarjetas')}\nElige la vista deseada:`;
     const msg = await ctx.reply(text, { parse_mode: 'HTML', reply_markup: kb.reply_markup });
     ctx.wizard.state.msgId = msg.message_id;
     ctx.wizard.state.lastRender = { text, reply_markup: kb.reply_markup };

--- a/helpers/format.js
+++ b/helpers/format.js
@@ -20,4 +20,8 @@ function fmtMoney(n) {
   return Number.parseFloat(n || 0).toFixed(2);
 }
 
-module.exports = { escapeHtml, fmtMoney };
+function boldHeader(icon, text) {
+  return `${icon} <b>${escapeHtml(text)}</b>`;
+}
+
+module.exports = { escapeHtml, fmtMoney, boldHeader };


### PR DESCRIPTION
## Summary
- add boldHeader helper to standardize titles
- use boldHeader across monitor, saldo, extracto and tarjetas assistants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c67da3b820832da66748d173d63059