### PR TITLE
Allow Scenes to persist across messages

### DIFF
--- a/app.js
+++ b/app.js
@@ -58,8 +58,7 @@ async function initDatabase() {
 
 /* ───────── 7. Scenes / Stage ───────── */
 const stage = new Scenes.Stage(
-  [tarjetaWizard, saldoWizard, tarjetasAssist, monitorAssist, accesoAssist, extractoAssist],
-  { ttl: 0 },
+  [tarjetaWizard, saldoWizard, tarjetasAssist, monitorAssist, accesoAssist, extractoAssist]
 );
 stage.hears(/^(salir)$/i, async (ctx) => {
   await flushOnExit(ctx);


### PR DESCRIPTION
## Summary
- Remove Stage TTL configuration so scene state survives between messages

## Testing
- `npm test`
- Manual wizard simulation verifying state persists across messages

------
https://chatgpt.com/codex/tasks/task_e_68c67f601544832dad9c5e8ddf012dce