### PR TITLE
Run fondo analysis when leaving saldo wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,10 @@ Estas utilidades facilitan la creación de asistentes consistentes:
 
 ## 🧮 Asesor de Fondo
 
-El middleware `middlewares/fondoAdvisor.js` genera un informe financiero cada vez que se cierran los asistentes de saldo,
-tarjetas, monitor o extracto (hook en el evento `leave`) y también mediante el comando `/fondo`. El análisis:
+El middleware `middlewares/fondoAdvisor.js` genera un informe financiero cada vez que se cierran los asistentes de tarjetas,
+monitor o extracto (hook en el evento `leave`). El asistente de `/saldo` dispara el análisis desde su propio
+`leaveMiddleware` para garantizar que, incluso si no se registra el middleware global, se envíe el reporte al finalizar. Además
+puede ejecutarse manualmente mediante el comando `/fondo`. El análisis:
 
 - Calcula la necesidad en CUP con `necesidad = |deudas| + colchón − activos` y exige un colchón mínimo de 150 000 CUP.
 - Lee la tasa SELL desde la tabla `moneda` (código `CUP`) y usa las variables `ADVISOR_*` como fallback.

--- a/README.test.md
+++ b/README.test.md
@@ -30,6 +30,8 @@ teclado de una sola fila.
 - `tests/commands/assistantsUX.test.js`: verifica que los asistentes
   terminen con el mensaje `Reporte generado.` seguido por los botones
   `💾 Salvar` y `❌ Salir`.
+- `tests/commands/saldo.leave.test.js`: asegura que el asistente de
+  saldo ejecute el asesor de fondo al salir.
 
 ## Flujo local (desarrollo)
 

--- a/agent.md
+++ b/agent.md
@@ -8,7 +8,7 @@
 
 ## Asesor de Fondo
 
-- `runFondo(ctx)` calcula la venta USD necesaria tras los asistentes de saldo/tarjetas/monitor/extracto usando `setImmediate`
-  en el evento `leave` para esperar la persistencia de saldos.
+- El asistente de `/saldo` llama a `runFondo(ctx)` desde su `leaveMiddleware`; los asistentes de tarjetas/monitor/extracto lo
+  hacen mediante el hook global en `registerFondoAdvisor` (usa `setImmediate` para esperar la persistencia de saldos).
 - El reporte se arma con HTML plano (sin `<br>`/`<ul>`) y se envía con `sendLargeMessage` en `parse_mode: 'HTML'`.
 - Los cálculos usan la tasa SELL de la base (fallback en env), aplican colchón de 150 000 CUP y clasifican urgencia 🔴/🟠/🟢.

--- a/commands/saldo.js
+++ b/commands/saldo.js
@@ -17,6 +17,7 @@ const { Scenes, Markup } = require('telegraf');
 const { escapeHtml, fmtMoney, boldHeader } = require('../helpers/format');
 const { sendAndLog } = require('../helpers/reportSender');
 const { recordChange, flushOnExit } = require('../helpers/sessionSummary');
+const { runFondo } = require('../middlewares/fondoAdvisor');
 const pool = require('../psql/db.js');
 const moment = require('moment-timezone');
 
@@ -384,9 +385,18 @@ const saldoWizard = new Scenes.WizardScene(
   }
 );
 
-saldoWizard.leave(async ctx => {
+async function handleSaldoLeave(ctx) {
   ctx.wizard.state = {};
-});
+
+  try {
+    await runFondo(ctx);
+  } catch (err) {
+    console.error('[SALDO_WIZ] error al generar análisis de fondo:', err);
+  }
+}
+
+saldoWizard.leave(handleSaldoLeave);
+saldoWizard.handleSaldoLeave = handleSaldoLeave;
 
 module.exports = saldoWizard;
 

--- a/middlewares/fondoAdvisor.js
+++ b/middlewares/fondoAdvisor.js
@@ -455,7 +455,6 @@ async function runFondo(ctx, opts = {}) {
 
 function registerFondoAdvisor({ scenes = {} } = {}) {
   const targets = [
-    scenes.saldoWizard,
     scenes.tarjetasAssist,
     scenes.monitorAssist,
     scenes.extractoAssist,

--- a/tests/__tests__/fondoAdvisor.wiring.test.js
+++ b/tests/__tests__/fondoAdvisor.wiring.test.js
@@ -38,13 +38,13 @@ describe('fondoAdvisor wiring', () => {
       },
     });
 
-    expect(saldoScene.on).toHaveBeenCalledWith('leave', expect.any(Function));
+    expect(saldoScene.on).not.toHaveBeenCalled();
     expect(tarjetasScene.on).toHaveBeenCalledWith('leave', expect.any(Function));
     expect(monitorScene.on).toHaveBeenCalledWith('leave', expect.any(Function));
     expect(extractoScene.on).toHaveBeenCalledWith('leave', expect.any(Function));
 
     const ctx = { session: {}, reply: jest.fn() };
-    await saldoScene.emit('leave', ctx);
+    await tarjetasScene.emit('leave', ctx);
     await new Promise((resolve) => setImmediate(resolve));
     expect(runSpy).toHaveBeenCalledWith(ctx);
 

--- a/tests/commands/saldo.leave.test.js
+++ b/tests/commands/saldo.leave.test.js
@@ -1,0 +1,24 @@
+'use strict';
+
+jest.mock('../../middlewares/fondoAdvisor', () => ({
+  runFondo: jest.fn().mockResolvedValue(null),
+}));
+
+const { runFondo } = require('../../middlewares/fondoAdvisor');
+const saldoWizard = require('../../commands/saldo');
+
+describe('saldo wizard leave hook', () => {
+  beforeEach(() => {
+    runFondo.mockClear();
+  });
+
+  it('ejecuta el análisis de fondo al abandonar el asistente', async () => {
+    const ctx = { wizard: { state: { foo: 'bar' } }, session: {} };
+
+    await saldoWizard.handleSaldoLeave(ctx);
+
+    expect(ctx.wizard.state).toEqual({});
+    expect(runFondo).toHaveBeenCalledTimes(1);
+    expect(runFondo).toHaveBeenCalledWith(ctx);
+  });
+});


### PR DESCRIPTION
## Summary
- trigger the fondo advisor analysis directly from the saldo wizard leave handler and expose the helper for reuse
- remove the saldo wizard from the global fondo advisor wiring, update the wiring test and add a dedicated leave test
- refresh README, README.test and agent notes to document the new behaviour and coverage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce56b91bbc832dab78645e5ad2937b