### PR TITLE
Refine fondo advisor sell guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,13 @@ monitor o extracto (hook en el evento `leave`). El asistente de `/saldo` dispara
 `leaveMiddleware` para garantizar que, incluso si no se registra el middleware global, se envíe el reporte al finalizar. Además
 puede ejecutarse manualmente mediante el comando `/fondo`. El análisis:
 
-- Calcula la necesidad en CUP con `necesidad = |deudas| + colchón − activos` y exige un colchón mínimo de 150 000 CUP.
+- Calcula la necesidad en CUP con `necesidad = |deudas| + colchón − activos`, permite configurar el colchón objetivo y deriva la venta objetivo/instantánea en USD con redondeos enteros.
 - Lee la tasa SELL desde la tabla `moneda` (código `CUP`) y usa las variables `ADVISOR_*` como fallback.
 - Ignora como liquidez las cuentas por cobrar cuyo banco/agente/número contenga “debe/deuda/deudor”.
-- Resume inventario USD, venta inmediata, faltante y estrategia opcional de compra por ciclos con BUY/SELL y mínimo USD.
-- Clasifica la urgencia en 🔴/🟠/🟢 y explica la fórmula en un mensaje HTML sin `<br>` ni `<ul>` usando `sendLargeMessage`.
-- Emite logs con prefijo `[fondoAdvisor]` para config, tasas, totales, necesidad, ventas y ciclos para facilitar auditorías.
-- Está cubierto por pruebas en `tests/__tests__/fondoAdvisor.test.js` con una cobertura superior al 95 % en la lógica pura.
+- Resume inventario USD disponible, venta inmediata, faltante tras la operación y muestra una alerta cuando el inventario está por debajo del mínimo permitido sin sugerir ciclos de compra/venta.
+- Clasifica la urgencia en 🔴/🟠/🟢, explica la fórmula y parámetros en un mensaje HTML sin `<br>` ni `<ul>` usando `sendLargeMessage`.
+- Emite logs con prefijo `[fondoAdvisor]` para config, tasas, totales, necesidad, ventas y urgencia para facilitar auditorías.
+- Está cubierto por pruebas en `tests/__tests__/fondoAdvisor.calc.test.js` y `tests/__tests__/fondoAdvisor.test.js` con una cobertura superior al 95 % en la lógica pura.
 
 ## UX de teclados
 

--- a/TODOs.md
+++ b/TODOs.md
@@ -8,3 +8,5 @@
 
 - Definir alertas automáticas cuando la urgencia 🔴 se repita en días consecutivos.
 - Evaluar ajustes del mínimo USD por operación según disponibilidad real de inventario.
+- Investigar recordatorios cuando exista faltante en CUP tras la venta inmediata.
+- Analizar UI para permitir modificar el colchón objetivo directamente desde el comando `/fondo`.

--- a/agent.md
+++ b/agent.md
@@ -11,4 +11,5 @@
 - El asistente de `/saldo` llama a `runFondo(ctx)` desde su `leaveMiddleware`; los asistentes de tarjetas/monitor/extracto lo
   hacen mediante el hook global en `registerFondoAdvisor` (usa `setImmediate` para esperar la persistencia de saldos).
 - El reporte se arma con HTML plano (sin `<br>`/`<ul>`) y se envía con `sendLargeMessage` en `parse_mode: 'HTML'`.
-- Los cálculos usan la tasa SELL de la base (fallback en env), aplican colchón de 150 000 CUP y clasifican urgencia 🔴/🟠/🟢.
+- El análisis calcula necesidad = |deudas| + colchón − activos, determina la venta objetivo/instantánea a la tasa SELL y clasifica urgencia 🔴/🟠/🟢 según inventario disponible.
+- Cuando el inventario USD no alcanza el mínimo configurado se muestra la alerta “⚠️ inventario menor al mínimo…”, y se omite cualquier sugerencia de ciclos de compra.

--- a/tests/__tests__/fondoAdvisor.calc.test.js
+++ b/tests/__tests__/fondoAdvisor.calc.test.js
@@ -7,95 +7,63 @@ const {
 
 describe('fondoAdvisor calculations', () => {
   describe('computeNeeds', () => {
-    it('returns zero need when cushion is satisfied', () => {
-      const result = computeNeeds({ activosCup: 200000, deudasCup: -50000, cushionTarget: 150000 });
-      expect(result.needCup).toBe(0);
-      expect(result.cushionTarget).toBe(150000);
-      expect(Math.round(result.disponibles)).toBe(150000);
+    it('respeta el colchón objetivo al sumar deudas y activos', () => {
+      const result = computeNeeds({ activosCup: 131654, deudasCup: -168764, cushionTarget: 100000 });
+      expect(result.needCup).toBe(137110);
+      expect(result.disponibles).toBe(-37110); // activos - |deudas|
+      expect(result.cushionTarget).toBe(100000);
+      expect(result.deudaAbs).toBe(168764);
     });
 
-    it('calculates additional need when cushion is not met', () => {
-      const result = computeNeeds({ activosCup: 120000, deudasCup: -30000, cushionTarget: 150000 });
-      expect(result.needCup).toBe(60000);
-      expect(result.cushionTarget).toBe(150000);
-      expect(Math.round(result.disponibles)).toBe(90000);
+    it('permite colchón cero y calcula necesidad mínima', () => {
+      const result = computeNeeds({ activosCup: 131654, deudasCup: -168764, cushionTarget: 0 });
+      expect(result.needCup).toBe(37110);
+      expect(result.disponibles).toBe(-37110);
+      expect(result.deudaAbs).toBe(168764);
     });
   });
 
-  describe('computePlan', () => {
-    it('cubre la necesidad vendiendo solo inventario USD', () => {
-      const plan = computePlan({
-        needCup: 50000,
-        usdInventory: 200,
-        sellRate: 452,
-        buyRate: 400,
-        minSellUsd: 40,
-        liquidityByBank: {},
-      });
-      expect(plan.sellTarget.usd).toBe(111);
-      expect(plan.sellNow.usd).toBe(111);
-      expect(plan.sellNow.cupIn).toBe(50172);
-      expect(plan.remainingCup).toBe(0);
-      expect(plan.urgency).toBe('🟢 NORMAL');
-    });
+  describe('computePlan con SELL 452 y mínimo 40 USD', () => {
+    const baseConfig = {
+      sellRate: 452,
+      minSellUsd: 40,
+    };
 
-    it('usa ciclos cuando no hay inventario USD', () => {
-      const plan = computePlan({
-        needCup: 80000,
-        usdInventory: 0,
-        sellRate: 452,
-        buyRate: 400,
-        minSellUsd: 40,
-        liquidityByBank: { BANDEC: 800000 },
-      });
-      expect(plan.sellTarget.usd).toBe(177);
+    it('case A: sin inventario disponible marca todo como faltante', () => {
+      const plan = computePlan({ needCup: 137110, usdInventory: 0, ...baseConfig });
+      expect(plan.status).toBe('NEED_ACTION');
+      expect(plan.sellTarget).toEqual({ usd: 304, cupIn: 137408 });
       expect(plan.sellNow.usd).toBe(0);
-      expect(plan.remainingCup).toBe(80000);
-      expect(plan.optionalCycle.usdPerCycle).toBe(2000);
-      expect(plan.optionalCycle.profitPerCycle).toBe(104000);
-      expect(plan.optionalCycle.cyclesNeeded).toBe(1);
-      expect(plan.urgency).toBe('🟢 NORMAL');
+      expect(plan.sellNow.minWarning).toBe(true);
+      expect(plan.remainingCup).toBe(137110);
+      expect(plan.remainingUsd).toBe(304);
     });
 
-    it('combina venta inmediata y ciclos para cubrir el faltante', () => {
-      const plan = computePlan({
-        needCup: 120000,
-        usdInventory: 100,
-        sellRate: 452,
-        buyRate: 400,
-        minSellUsd: 40,
-        liquidityByBank: { BANDEC: 600000 },
-      });
-      expect(plan.sellNow.usd).toBe(100);
-      expect(plan.sellNow.cupIn).toBe(45200);
-      expect(plan.remainingCup).toBe(74800);
-      expect(plan.optionalCycle.usdPerCycle).toBe(1500);
-      expect(plan.optionalCycle.profitPerCycle).toBe(78000);
-      expect(plan.optionalCycle.cyclesNeeded).toBe(1);
-      expect(plan.urgency).toBe('🟢 NORMAL');
-    });
-
-    it('marca urgencia cuando la liquidez rápida no alcanza', () => {
-      const plan = computePlan({
-        needCup: 90000,
-        usdInventory: 0,
-        sellRate: 452,
-        buyRate: 400,
-        minSellUsd: 40,
-        liquidityByBank: { BANDEC: 20000 },
-      });
-      expect(plan.optionalCycle.usdPerCycle).toBe(50);
-      expect(plan.optionalCycle.profitPerCycle).toBe(2600);
-      expect(plan.optionalCycle.cyclesNeeded).toBe(35);
-      expect(plan.remainingCup).toBe(90000);
-      expect(plan.urgency).toBe('🔴 URGENTE');
-    });
-
-    it('reporta normalidad cuando no hay necesidad adicional', () => {
-      const plan = computePlan({ needCup: 0, usdInventory: 0, sellRate: 452, buyRate: 400 });
-      expect(plan.sellTarget.usd).toBe(0);
+    it('case B: inventario suficiente cubre la necesidad completa', () => {
+      const plan = computePlan({ needCup: 37110, usdInventory: 200, ...baseConfig });
+      expect(plan.sellTarget).toEqual({ usd: 83, cupIn: 37516 });
+      expect(plan.sellNow.usd).toBe(83);
+      expect(plan.sellNow.cupIn).toBe(37516);
       expect(plan.remainingCup).toBe(0);
-      expect(plan.urgency).toBe('🟢 NORMAL');
+      expect(plan.remainingUsd).toBe(0);
+    });
+
+    it('case C: inventario menor al mínimo detiene la venta inmediata', () => {
+      const plan = computePlan({ needCup: 37110, usdInventory: 20, ...baseConfig });
+      expect(plan.sellTarget.usd).toBe(83);
+      expect(plan.sellNow.usd).toBe(0);
+      expect(plan.sellNow.minWarning).toBe(true);
+      expect(plan.remainingCup).toBe(37110);
+      expect(plan.remainingUsd).toBe(83);
+    });
+
+    it('sin necesidad devuelve estado OK y montos en cero', () => {
+      const plan = computePlan({ needCup: 0, usdInventory: 500, ...baseConfig });
+      expect(plan.status).toBe('OK');
+      expect(plan.sellTarget.usd).toBe(0);
+      expect(plan.sellNow.usd).toBe(0);
+      expect(plan.remainingCup).toBe(0);
+      expect(plan.remainingUsd).toBe(0);
     });
   });
 });

--- a/tests/__tests__/fondoAdvisor.test.js
+++ b/tests/__tests__/fondoAdvisor.test.js
@@ -17,77 +17,24 @@ afterEach(() => {
 });
 
 describe('fondoAdvisor core calculations', () => {
-  test('computeNeeds aplica fórmula principal', () => {
+  test('computeNeeds aplica fórmula principal con redondeo', () => {
     const result = computeNeeds({
-      activosCup: 161654.19,
-      deudasCup: -168763.99,
+      activosCup: 161654,
+      deudasCup: -168764,
       cushionTarget: 150000,
     });
     expect(result.needCup).toBe(157110);
     expect(result.deudaAbs).toBe(168764);
-    expect(result.disponibles).toBe(-7110);
+    expect(result.disponibles).toBe(-7110); // 161654 - 168764
   });
 
-  describe('computePlan con tasas estándar', () => {
-    const baseOptions = {
-      needCup: 157110,
-      sellRate: 452,
-      buyRate: 400,
-      minSellUsd: 40,
-      liquidityByBank: {
-        BANDEC: 70771.82,
-        MITRANSFER: 53628.0,
-        METRO: 5909.37,
-        BPA: 1345.0,
-      },
-    };
-
-    test('sin inventario disponible recurre a ciclos', () => {
-      const plan = computePlan({ ...baseOptions, usdInventory: 0 });
-      expect(plan.sellTarget.usd).toBe(348);
-      expect(plan.sellTarget.cupIn).toBe(157296);
-      expect(plan.sellNow.usd).toBe(0);
-      expect(plan.remainingCup).toBe(157110);
-      expect(plan.optionalCycle.usdPerCycle).toBe(329);
-      expect(plan.optionalCycle.profitPerCycle).toBe(17108);
-      expect(plan.optionalCycle.cyclesNeeded).toBe(10);
-      expect(plan.urgency).toBe('🔴 URGENTE');
-    });
-
-    test('con 200 USD inventario reduce ciclos y prioridad', () => {
-      const plan = computePlan({ ...baseOptions, usdInventory: 200 });
-      expect(plan.sellNow.usd).toBe(200);
-      expect(plan.sellNow.cupIn).toBe(90400);
-      expect(plan.remainingCup).toBe(66710);
-      expect(plan.optionalCycle.cyclesNeeded).toBe(4);
-      expect(plan.urgency).toBe('🟠 PRIORITARIO');
-    });
-
-    test('inventario bajo mínimo y liquidez insuficiente por ciclo', () => {
-      const tinyPlan = computePlan({
-        needCup: 10000,
-        usdInventory: 20,
-        sellRate: 452,
-        buyRate: 400,
-        minSellUsd: 40,
-        liquidityByBank: { BANDEC: 1000 },
-      });
-      expect(tinyPlan.sellNow.usd).toBe(20);
-      expect(tinyPlan.sellNow.minWarning).toBe(true);
-      expect(tinyPlan.optionalCycle.usdPerCycle).toBe(2);
-      expect(tinyPlan.optionalCycle.belowMin).toBe(true);
-      expect(tinyPlan.optionalCycle.cyclesNeeded).toBe(10);
-      expect(tinyPlan.urgency).toBe('🔴 URGENTE');
-    });
-  });
-
-  test('aggregateBalances ignora cuentas por cobrar marcadas como deuda', () => {
+  test('aggregateBalances ignora cuentas por cobrar y convierte USD', () => {
     const rows = [
       {
         moneda: 'CUP',
         banco: 'BANDEC',
         agente: 'Cliente Deuda',
-        numero: '*debe*',
+        numero: 'Cuenta debe',
         saldo: 5000,
         tasa_usd: 1,
       },
@@ -95,14 +42,31 @@ describe('fondoAdvisor core calculations', () => {
         moneda: 'CUP',
         banco: 'BANDEC',
         agente: 'Cliente Deuda',
-        numero: '*debe*',
+        numero: 'Cuenta debe',
         saldo: -5000,
         tasa_usd: 1,
       },
+      {
+        moneda: 'USD',
+        banco: 'BANDEC',
+        agente: 'Caja fuerte',
+        numero: '1111',
+        saldo: 900,
+        tasa_usd: 1,
+      },
+      {
+        moneda: 'MLC',
+        banco: 'BPA',
+        agente: 'Caja fuerte',
+        numero: '2222',
+        saldo: 45200,
+        tasa_usd: 452,
+      },
     ];
-    const totals = aggregateBalances(rows, ['BANDEC']);
+    const totals = aggregateBalances(rows, ['BANDEC', 'BPA']);
     expect(totals.activosCup).toBe(0);
     expect(totals.deudasCup).toBe(-5000);
+    expect(Math.round(totals.usdInventory)).toBe(1000);
     expect(totals.liquidityByBank.BANDEC || 0).toBe(0);
   });
 
@@ -121,36 +85,35 @@ describe('fondoAdvisor core calculations', () => {
       BPA: 1345.0,
     };
     const needs = computeNeeds({
-      activosCup: 161654.19,
-      deudasCup: -168763.99,
+      activosCup: 161654,
+      deudasCup: -168764,
       cushionTarget: config.cushion,
     });
     const plan = computePlan({
       needCup: needs.needCup,
       usdInventory: 200,
       sellRate: config.sellRate,
-      buyRate: config.buyRate,
       minSellUsd: config.minSellUsd,
-      liquidityByBank: liquidity,
     });
     const result = {
-      activosCup: 161654.19,
-      deudasCup: -168763.99,
-      netoCup: 161654.19 - 168763.99,
+      activosCup: 161654,
+      deudasCup: -168764,
+      netoCup: 161654 - 168764,
       ...needs,
       plan,
       liquidityByBank: liquidity,
       config,
+      urgency: '🟠 PRIORITARIO',
     };
     const blocks = renderAdvice(result);
     const message = blocks.join('\n\n');
     expect(Array.isArray(blocks)).toBe(true);
-    expect(message).toContain('💸 <b>Venta requerida</b>');
+    expect(message).toContain('💸 <b>Venta requerida (Zelle)</b>');
     expect(message).toContain('Objetivo: vender 348 USD a 452 ⇒ +157,296 CUP');
     expect(message).toContain('Vende ahora: 200 USD ⇒ +90,400 CUP');
-    expect(message).toContain('🛒 <b>Compra por ciclos (opcional)</b>');
-    expect(message).toContain('🟠 PRIORITARIO');
-    expect(message).toContain('Faltante tras venta: 66,710 CUP');
+    expect(message).toContain('Faltante tras venta: 66,710 CUP (≈ 148 USD)');
+    expect(message).toContain('🏦 <b>Liquidez rápida disponible</b>');
+    expect(message).not.toContain('ciclos');
     expect(message).not.toContain('<br>');
     expect(message).not.toContain('<ul>');
   });

--- a/tests/__tests__/fondoAdvisor.wiring.test.js
+++ b/tests/__tests__/fondoAdvisor.wiring.test.js
@@ -72,10 +72,10 @@ describe('fondoAdvisor wiring', () => {
     expect(send).toHaveBeenCalledTimes(1);
     const message = send.mock.calls[0][0];
     expect(message).toContain('Asesor de Fondo');
-    expect(message).toContain('Venta requerida');
-    expect(message).toContain('Compra por ciclos');
+    expect(message).toContain('Venta requerida (Zelle)');
+    expect(message).toContain('Faltante tras venta');
     expect(message).toContain('Liquidez rápida disponible');
     expect(result.plan.remainingCup).toBeGreaterThan(0);
-    expect(result.plan.urgency).toBe('🟠 PRIORITARIO');
+    expect(result.urgency).toBe('🟠 PRIORITARIO');
   });
 });


### PR DESCRIPTION
## Summary
- update the fondo advisor aggregation and plan logic to work entirely with direct USD sales, compute urgency, and surface minimum-inventory warnings
- refresh the HTML renderer to focus on required sales, remaining gaps, and quick-liquidity totals while removing cycle guidance
- document the new behaviour and expand the dedicated Jest coverage for needs, plans, wiring, and rendering

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce65fa6fd4832da5aa5369e951f02f