### PR TITLE
Refina asesor de fondo para ventas sin ciclos

### DIFF
--- a/tests/__tests__/fondoAdvisor.calc.test.js
+++ b/tests/__tests__/fondoAdvisor.calc.test.js
@@ -3,67 +3,112 @@
 const {
   computeNeeds,
   computePlan,
+  computeProjection,
+  aggregateBalances,
 } = require('../../middlewares/fondoAdvisor');
 
-describe('fondoAdvisor calculations', () => {
-  describe('computeNeeds', () => {
-    it('respeta el colchón objetivo al sumar deudas y activos', () => {
-      const result = computeNeeds({ activosCup: 131654, deudasCup: -168764, cushionTarget: 100000 });
-      expect(result.needCup).toBe(137110);
-      expect(result.disponibles).toBe(-37110); // activos - |deudas|
-      expect(result.cushionTarget).toBe(100000);
-      expect(result.deudaAbs).toBe(168764);
-    });
+const BASE_CONFIG = {
+  sellRate: 452,
+  minSellUsd: 40,
+  sellFeePct: 0,
+  fxMarginPct: 0,
+  sellRoundToUsd: 1,
+  minKeepUsd: 0,
+  sellRateSource: 'env',
+};
 
-    it('permite colchón cero y calcula necesidad mínima', () => {
-      const result = computeNeeds({ activosCup: 131654, deudasCup: -168764, cushionTarget: 0 });
-      expect(result.needCup).toBe(37110);
-      expect(result.disponibles).toBe(-37110);
-      expect(result.deudaAbs).toBe(168764);
-    });
+describe('fondoAdvisor pure calculations', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
   });
 
-  describe('computePlan con SELL 452 y mínimo 40 USD', () => {
-    const baseConfig = {
-      sellRate: 452,
-      minSellUsd: 40,
-    };
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
-    it('case A: sin inventario disponible marca todo como faltante', () => {
-      const plan = computePlan({ needCup: 137110, usdInventory: 0, ...baseConfig });
-      expect(plan.status).toBe('NEED_ACTION');
-      expect(plan.sellTarget).toEqual({ usd: 304, cupIn: 137408 });
-      expect(plan.sellNow.usd).toBe(0);
-      expect(plan.sellNow.minWarning).toBe(true);
-      expect(plan.remainingCup).toBe(137110);
-      expect(plan.remainingUsd).toBe(304);
-    });
+  test('needCup sin colchón y con colchón objetivo', () => {
+    const base = { activosCup: 131654, deudasCup: -168764 };
+    const noCushion = computeNeeds({ ...base, cushionTarget: 0 });
+    expect(noCushion.needCup).toBe(37110);
+    expect(noCushion.disponibles).toBe(-37110);
+    expect(noCushion.deudaAbs).toBe(168764);
 
-    it('case B: inventario suficiente cubre la necesidad completa', () => {
-      const plan = computePlan({ needCup: 37110, usdInventory: 200, ...baseConfig });
-      expect(plan.sellTarget).toEqual({ usd: 83, cupIn: 37516 });
-      expect(plan.sellNow.usd).toBe(83);
-      expect(plan.sellNow.cupIn).toBe(37516);
-      expect(plan.remainingCup).toBe(0);
-      expect(plan.remainingUsd).toBe(0);
-    });
+    const withCushion = computeNeeds({ ...base, cushionTarget: 100000 });
+    expect(withCushion.needCup).toBe(137110);
+    expect(withCushion.disponibles).toBe(-37110);
+    expect(withCushion.deudaAbs).toBe(168764);
+  });
 
-    it('case C: inventario menor al mínimo detiene la venta inmediata', () => {
-      const plan = computePlan({ needCup: 37110, usdInventory: 20, ...baseConfig });
-      expect(plan.sellTarget.usd).toBe(83);
-      expect(plan.sellNow.usd).toBe(0);
-      expect(plan.sellNow.minWarning).toBe(true);
-      expect(plan.remainingCup).toBe(37110);
-      expect(plan.remainingUsd).toBe(83);
+  test('venta sin inventario respeta mínimo por operación', () => {
+    const plan = computePlan({
+      needCup: 37110,
+      usdInventory: 0,
+      ...BASE_CONFIG,
     });
+    expect(plan.sellNet).toBe(452);
+    expect(plan.sellTarget).toEqual({ usd: 83, cupIn: 37516 });
+    expect(plan.sellNow).toEqual({ usd: 0, cupIn: 0, minWarning: true });
+    expect(plan.remainingCup).toBe(37110);
+    expect(plan.remainingUsd).toBe(83);
+  });
 
-    it('sin necesidad devuelve estado OK y montos en cero', () => {
-      const plan = computePlan({ needCup: 0, usdInventory: 500, ...baseConfig });
-      expect(plan.status).toBe('OK');
-      expect(plan.sellTarget.usd).toBe(0);
-      expect(plan.sellNow.usd).toBe(0);
-      expect(plan.remainingCup).toBe(0);
-      expect(plan.remainingUsd).toBe(0);
+  test('venta con inventario suficiente cubre todo y proyecta colchón', () => {
+    const plan = computePlan({
+      needCup: 37110,
+      usdInventory: 500,
+      ...BASE_CONFIG,
     });
+    expect(plan.sellTarget).toEqual({ usd: 83, cupIn: 37516 });
+    expect(plan.sellNow).toEqual({ usd: 83, cupIn: 37516 });
+    expect(plan.remainingCup).toBe(0);
+    expect(plan.remainingUsd).toBe(0);
+
+    const projection = computeProjection(131654, -168764, plan.sellNow.cupIn);
+    expect(projection).toEqual({ negativosPost: 0, colchonPost: 169170 });
+  });
+
+  test('aplica fee, margen FX y redondeo', () => {
+    const plan = computePlan({
+      needCup: 37110,
+      usdInventory: 100,
+      ...BASE_CONFIG,
+      sellFeePct: 0.004,
+      fxMarginPct: 0.01,
+      sellRoundToUsd: 5,
+    });
+    expect(plan.sellNet).toBe(450);
+    expect(plan.sellTarget).toEqual({ usd: 85, cupIn: 38250 });
+    expect(plan.sellNow).toEqual({ usd: 85, cupIn: 38250 });
+    expect(plan.remainingCup).toBe(0);
+  });
+
+  test('respeta redondeo y reserva mínima de inventario', () => {
+    const plan = computePlan({
+      needCup: 37110,
+      usdInventory: 2400,
+      ...BASE_CONFIG,
+      sellRoundToUsd: 10,
+      minKeepUsd: 50,
+    });
+    expect(plan.sellTarget).toEqual({ usd: 90, cupIn: 40680 });
+    expect(plan.sellNow).toEqual({ usd: 90, cupIn: 40680 });
+  });
+
+  test('aggregateBalances ignora por cobrar y suma USD reales', () => {
+    const rows = [
+      { moneda: 'CUP', banco: 'BANDEC', agente: 'Caja operativa', numero: 'Cuenta 1', saldo: 120000, tasa_usd: 1 },
+      { moneda: 'CUP', banco: 'BANDEC', agente: 'Cliente Deudor', numero: 'Cuenta deuda', saldo: -5000, tasa_usd: 1 },
+      { moneda: 'CUP', banco: 'BANDEC', agente: 'Pago debe', numero: 'Por cobrar', saldo: 10000, tasa_usd: 1 },
+      { moneda: 'USD', banco: 'BANDEC', agente: 'Caja fuerte', numero: '1111', saldo: 900, tasa_usd: 1 },
+      { moneda: 'MLC', banco: 'BPA', agente: 'Caja fuerte', numero: '2222', saldo: 45200, tasa_usd: 452 },
+    ];
+
+    const totals = aggregateBalances(rows, ['BANDEC', 'BPA']);
+    expect(totals.activosCup).toBe(120000);
+    expect(totals.deudasCup).toBe(-5000);
+    expect(Math.floor(totals.usdInventory)).toBe(1000);
+    expect(totals.liquidityByBank.BANDEC).toBe(120000);
+    expect(totals.liquidityByBank.BPA).toBeUndefined();
   });
 });

--- a/tests/__tests__/fondoAdvisor.test.js
+++ b/tests/__tests__/fondoAdvisor.test.js
@@ -2,9 +2,10 @@
 
 const {
   computeNeeds,
-  computePlan,
   renderAdvice,
   aggregateBalances,
+  computePlan,
+  computeProjection,
 } = require('../../middlewares/fondoAdvisor');
 
 beforeEach(() => {
@@ -73,10 +74,13 @@ describe('fondoAdvisor core calculations', () => {
   test('renderAdvice genera mensaje en español sin etiquetas prohibidas', () => {
     const config = {
       cushion: 150000,
-      buyRate: 400,
       sellRate: 452,
       minSellUsd: 40,
       liquidityBanks: ['BANDEC', 'MITRANSFER', 'METRO', 'BPA'],
+      sellFeePct: 0,
+      fxMarginPct: 0,
+      sellRoundToUsd: 1,
+      minKeepUsd: 0,
     };
     const liquidity = {
       BANDEC: 70771.82,
@@ -94,13 +98,20 @@ describe('fondoAdvisor core calculations', () => {
       usdInventory: 200,
       sellRate: config.sellRate,
       minSellUsd: config.minSellUsd,
+      sellFeePct: config.sellFeePct,
+      fxMarginPct: config.fxMarginPct,
+      sellRoundToUsd: config.sellRoundToUsd,
+      minKeepUsd: config.minKeepUsd,
+      sellRateSource: 'env',
     });
+    const projection = computeProjection(161654, -168764, plan.sellNow.cupIn);
     const result = {
       activosCup: 161654,
       deudasCup: -168764,
       netoCup: 161654 - 168764,
       ...needs,
       plan,
+      projection,
       liquidityByBank: liquidity,
       config,
       urgency: '🟠 PRIORITARIO',
@@ -112,6 +123,8 @@ describe('fondoAdvisor core calculations', () => {
     expect(message).toContain('Objetivo: vender 348 USD a 452 ⇒ +157,296 CUP');
     expect(message).toContain('Vende ahora: 200 USD ⇒ +90,400 CUP');
     expect(message).toContain('Faltante tras venta: 66,710 CUP (≈ 148 USD)');
+    expect(message).toContain('🧾 <b>Proyección post-venta</b>');
+    expect(message).toContain('Colchón proyectado: 252,054 CUP');
     expect(message).toContain('🏦 <b>Liquidez rápida disponible</b>');
     expect(message).not.toContain('ciclos');
     expect(message).not.toContain('<br>');


### PR DESCRIPTION
## Summary
- recalcula la necesidad de CUP y plan de venta eliminando ciclos, aplicando comisiones, márgenes y redondeos configurables
- proyecta el colchón post-venta, muestra urgencia clara y resume parámetros operativos en el informe HTML
- amplía la suite de pruebas unitarias para cubrir los nuevos escenarios de cálculo y asegurar la agregación de saldos

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce6c320e20832da170aa55e6d2a2ea