### PR TITLE
Add global Telegram fallback handler and tighten advisor tables

### DIFF
--- a/helpers/reportSender.js
+++ b/helpers/reportSender.js
@@ -10,6 +10,7 @@
 
 const { statsChatId, comercialesGroupId, ownerIds } = require('../config');
 const { escapeHtml } = require('./format');
+const { safeReply, safeSendMessage } = require('./telegram');
 
 /* -------------------------------------------------------------------------- */
 /* Owners                                                                     */
@@ -17,7 +18,7 @@ const { escapeHtml } = require('./format');
 async function notifyOwners(ctx, html, extra = {}) {
   for (const id of ownerIds) {
     try {
-      await ctx.telegram.sendMessage(id, html, {
+      await safeSendMessage(ctx.telegram, id, html, {
         parse_mode: 'HTML',
         disable_web_page_preview: true,
         ...extra,
@@ -45,7 +46,7 @@ async function sendAndLog(ctx, html, extra = {}) {
       disable_web_page_preview: true,
       ...extra, // reply_markup o lo que venga del caller
     };
-    message = await ctx.reply(safe, opts);
+    message = await safeReply(ctx, safe, opts);
   } catch (err) {
     console.error('[reportSender] error ctx.reply', err);
     await notifyOwners(
@@ -60,7 +61,7 @@ async function sendAndLog(ctx, html, extra = {}) {
   /* 2⃣  Reenvío al grupo de estadísticas */
   if (statsChatId) {
     try {
-      await ctx.telegram.sendMessage(statsChatId, safe, {
+      await safeSendMessage(ctx.telegram, statsChatId, safe, {
         parse_mode: 'HTML',
         disable_web_page_preview: true,
       });
@@ -76,7 +77,7 @@ async function sendAndLog(ctx, html, extra = {}) {
   /* 3⃣  Reenvío al grupo de comerciales (si existe) */
   if (comercialesGroupId) {
     try {
-      await ctx.telegram.sendMessage(comercialesGroupId, safe, {
+      await safeSendMessage(ctx.telegram, comercialesGroupId, safe, {
         parse_mode: 'HTML',
         disable_web_page_preview: true,
       });

--- a/helpers/sendLargeMessage.js
+++ b/helpers/sendLargeMessage.js
@@ -11,9 +11,11 @@
 //   2. Si un bloque supera el límite, se corta en saltos de línea o
 //      espacios cuidando de no romper etiquetas HTML.
 //   3. Enviar las partes numeradas (1/N) solo cuando N > 1.
-//   4. Fallback sin parse_mode si Telegram rechaza el HTML.
+//   4. Fallback sin parse_mode (texto plano) si Telegram rechaza el HTML.
 //
 // También registra por consola cuántas partes se enviaron y su tamaño.
+
+const { safeReply } = require('./telegram');
 
 const MAX_CHARS = 4000; // margen respecto al límite de 4096
 
@@ -116,11 +118,7 @@ async function sendLargeMessage(ctx, blocks = [], opts = {}) {
   for (let i = 0; i < total; i++) {
     const prefix = total > 1 ? `(${i + 1}/${total})\n` : '';
     const msg = sanitizeUtf8(prefix + chunks[i]);
-    try {
-      await ctx.reply(msg, { parse_mode: 'HTML', ...opts });
-    } catch (err) {
-      await ctx.reply(msg, opts); // fallback sin parse_mode
-    }
+    await safeReply(ctx, msg, { parse_mode: 'HTML', ...opts });
     sizes.push(msg.length);
     await new Promise((r) => setTimeout(r, 300));
   }

--- a/helpers/sessionSummary.js
+++ b/helpers/sessionSummary.js
@@ -1,5 +1,6 @@
 const { notifyOwners } = require('./reportSender');
 const { fmtMoney, escapeHtml } = require('./format');
+const { safeSendMessage } = require('./telegram');
 const { ownerIds, statsChatId, comercialesGroupId } = require('../config');
 const db = require('../psql/db.js');
 const { query } = db;
@@ -30,7 +31,7 @@ function formatDate(d) {
 async function broadcast(ctx, recipients, html) {
   for (const id of recipients) {
     try {
-      await ctx.telegram.sendMessage(id, html, { parse_mode: 'HTML' });
+      await safeSendMessage(ctx.telegram, id, html, { parse_mode: 'HTML' });
     } catch (err) {
       console.error('[sessionSummary] error enviando a', id, err.message);
     }

--- a/helpers/telegram.js
+++ b/helpers/telegram.js
@@ -1,0 +1,91 @@
+'use strict';
+
+// helpers/telegram.js
+// -----------------------------------------------------------------------------
+// Utilidades centralizadas para manejar errores comunes al usar la API de
+// Telegram. En especial, los errores "can't parse entities" (HTML inválido)
+// y "Unsupported start tag" suelen aparecer cuando enviamos textos complejos
+// con parse_mode: 'HTML'. Este módulo expone funciones que permiten degradar
+// el mensaje a texto plano de forma segura y reutilizable.
+// -----------------------------------------------------------------------------
+
+const ENTITY_PARSE_RE = /can't parse entities/i;
+const UNSUPPORTED_TAG_RE = /unsupported start tag/i;
+
+function normalizeErrorMessage(err = {}) {
+  return (
+    err?.response?.description ||
+    err?.description ||
+    err?.message ||
+    ''
+  );
+}
+
+function isEntityParseError(err) {
+  const message = normalizeErrorMessage(err);
+  return ENTITY_PARSE_RE.test(message) || UNSUPPORTED_TAG_RE.test(message);
+}
+
+function htmlToPlainText(html = '') {
+  if (!html) return '';
+  return String(html)
+    .replace(/<\s*br\s*\/?\s*>/gi, '\n')
+    .replace(/<\s*\/?p[^>]*>/gi, '\n')
+    .replace(/<\s*\/?div[^>]*>/gi, '\n')
+    .replace(/<\s*\/?pre[^>]*>/gi, '\n')
+    .replace(/<\s*\/?code[^>]*>/gi, '')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/\n{3,}/g, '\n\n')
+    .trimEnd();
+}
+
+function buildFallbackExtra(extra = {}) {
+  const fallback = { ...extra };
+  delete fallback.parse_mode;
+  delete fallback.entities;
+  return fallback;
+}
+
+async function safeReply(ctx, text, extra = {}, { transformText } = {}) {
+  const options = { ...extra };
+  try {
+    return await ctx.reply(text, options);
+  } catch (err) {
+    if (!isEntityParseError(err) || !options.parse_mode) throw err;
+    const fallbackText = transformText
+      ? transformText(text, options, err)
+      : htmlToPlainText(text);
+    const fallbackExtra = buildFallbackExtra(options);
+    console.warn(
+      '[telegram] parse error en ctx.reply, degradando mensaje:',
+      normalizeErrorMessage(err),
+    );
+    return ctx.reply(fallbackText, fallbackExtra);
+  }
+}
+
+async function safeSendMessage(telegram, chatId, text, extra = {}, { transformText } = {}) {
+  const options = { ...extra };
+  try {
+    return await telegram.sendMessage(chatId, text, options);
+  } catch (err) {
+    if (!isEntityParseError(err) || !options.parse_mode) throw err;
+    const fallbackText = transformText
+      ? transformText(text, options, err)
+      : htmlToPlainText(text);
+    const fallbackExtra = buildFallbackExtra(options);
+    console.warn(
+      `[telegram] parse error enviando a ${chatId}, degradando mensaje:`,
+      normalizeErrorMessage(err),
+    );
+    return telegram.sendMessage(chatId, fallbackText, fallbackExtra);
+  }
+}
+
+module.exports = {
+  safeReply,
+  safeSendMessage,
+  htmlToPlainText,
+  isEntityParseError,
+};

--- a/middlewares/fondoAdvisor.js
+++ b/middlewares/fondoAdvisor.js
@@ -661,11 +661,14 @@ function renderAdvice(result) {
   const limitDefaultFmt = formatInteger(config.limitMonthlyDefaultCup ?? DEFAULT_CONFIG.limitMonthlyDefaultCup);
   const limitBpaFmt = formatInteger(config.limitMonthlyBpaCup ?? config.limitMonthlyDefaultCup ?? DEFAULT_CONFIG.limitMonthlyBpaCup);
   const limitInfoLine = `ℹ️ Límite mensual: Estándar ${limitDefaultFmt} CUP • BPA ${limitBpaFmt} CUP (ampliable)`;
+  const bankWidth = 6;
+  const cardWidth = 12;
+  const valueWidth = 9;
   const limitPreLines = [];
   if (!orderedCards.length) {
     limitPreLines.push('—');
   } else {
-    const hdr = `${'Banco'.padEnd(8)} ${'Tarjeta'.padEnd(13)} ${'SAL'.padStart(10)} ${'SALDO'.padStart(10)} ${'LIBRE'.padStart(10)} ${'CAP'.padStart(10)}  Estado`;
+    const hdr = `${'Banco'.padEnd(bankWidth)} ${'Tarjeta'.padEnd(cardWidth)} ${'SAL'.padStart(valueWidth)} ${'SALDO'.padStart(valueWidth)} ${'LIBRE'.padStart(valueWidth)} ${'CAP'.padStart(valueWidth)} Estado`;
     const dash = '─'.repeat(hdr.length);
     limitPreLines.push(hdr, dash);
     let totalSal = 0;
@@ -683,20 +686,20 @@ function renderAdvice(result) {
       totalSaldo += saldo;
       totalLibre += libre;
       totalCap += cap;
-      const salStr = formatInteger(sal).padStart(10);
-      const saldoStr = formatInteger(saldo).padStart(10);
-      const remainingStr = formatInteger(libre).padStart(10);
-      const capStr = formatInteger(cap).padStart(10);
+      const salStr = formatInteger(sal).padStart(valueWidth);
+      const saldoStr = formatInteger(saldo).padStart(valueWidth);
+      const remainingStr = formatInteger(libre).padStart(valueWidth);
+      const capStr = formatInteger(cap).padStart(valueWidth);
       const statusText = describeLimitStatus(card.status);
-      const line = `${bank.padEnd(8)} ${mask.padEnd(13)} ${salStr} ${saldoStr} ${remainingStr} ${capStr}  ${statusText}`;
+      const line = `${bank.padEnd(bankWidth)} ${mask.padEnd(cardWidth)} ${salStr} ${saldoStr} ${remainingStr} ${capStr} ${statusText}`;
       limitPreLines.push(line);
     });
-    const salTotStr = formatInteger(totalSal).padStart(10);
-    const saldoTotStr = formatInteger(totalSaldo).padStart(10);
-    const libreTotStr = formatInteger(totalLibre).padStart(10);
-    const capTotStr = formatInteger(totalCap).padStart(10);
+    const salTotStr = formatInteger(totalSal).padStart(valueWidth);
+    const saldoTotStr = formatInteger(totalSaldo).padStart(valueWidth);
+    const libreTotStr = formatInteger(totalLibre).padStart(valueWidth);
+    const capTotStr = formatInteger(totalCap).padStart(valueWidth);
     limitPreLines.push(dash);
-    limitPreLines.push(`${'TOTAL'.padEnd(8)} ${''.padEnd(13)} ${salTotStr} ${saldoTotStr} ${libreTotStr} ${capTotStr}`);
+    limitPreLines.push(`${'TOTAL'.padEnd(bankWidth)} ${''.padEnd(cardWidth)} ${salTotStr} ${saldoTotStr} ${libreTotStr} ${capTotStr}`);
   }
 
   const distNow = distributionNow || { assignments: [], leftover: 0, totalAssigned: 0 };
@@ -711,20 +714,22 @@ function renderAdvice(result) {
       suggestionPreLines.push('  Sin capacidad disponible');
     } else {
       // Encabezado de columnas para filas compactas
-      const hdr  = `  ${'Banco'.padEnd(8)} ${'Tarjeta'.padEnd(13)} ${'↦ CUP'.padStart(10)}   ${'cap antes→desp'.padEnd(21)} Estado`;
+      const assignWidth = 8;
+      const capWidth = valueWidth * 2 + 1;
+      const hdr  = `  ${'Banco'.padEnd(bankWidth)} ${'Tarjeta'.padEnd(cardWidth)} ${'↦ CUP'.padStart(assignWidth)} ${'cap antes→desp'.padEnd(capWidth)} Estado`;
       const dash = '  ' + '─'.repeat(hdr.trimStart().length);
       suggestionPreLines.push(hdr, dash);
       distribution.assignments.forEach((item) => {
         const bank = (item.bank || '').toUpperCase();
         const mask = item.mask || maskCardNumber(item.numero);
-        const assignStr = formatInteger(item.assignCup).padStart(9);
-        const beforeStr = formatInteger(item.remainingAntes).padStart(10);
-        const afterStr  = formatInteger(item.remainingDespues).padStart(10);
+        const assignStr = formatInteger(item.assignCup).padStart(assignWidth);
+        const beforeStr = formatInteger(item.remainingAntes).padStart(valueWidth);
+        const afterStr  = formatInteger(item.remainingDespues).padStart(valueWidth);
         const flag      = describeAllocationStatus(item.status);
         const bolsaTag  = item.isBolsa ? ' 🧳 fallback' : '';
         if (item.isBolsa) usedBolsaInDistribution = true;
-        const cap = `${beforeStr}→${afterStr}`.padEnd(21);
-        const line = `  ${bank.padEnd(8)} ${mask.padEnd(13)} ${assignStr}   ${cap} ${flag}${bolsaTag}`;
+        const cap = `${beforeStr}→${afterStr}`.padEnd(capWidth);
+        const line = `  ${bank.padEnd(bankWidth)} ${mask.padEnd(cardWidth)} ${assignStr} ${cap} ${flag}${bolsaTag}`;
         suggestionPreLines.push(line);
       });
     }


### PR DESCRIPTION
## Summary
- add helpers/telegram utilities to degrade HTML messages when Telegram rejects parse_mode
- reuse the global safeReply/safeSendMessage wrapper in large message and report senders
- compact fondoAdvisor tables to reduce spacing and message size

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cef50e7c68832d9b3383b75d00dfa4