### PR TITLE
Expose buy rate in fondo report and restore assistant navigation

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,6 +1,7 @@
 # Agent Notes
 
 - `buildSaveExitRow()` genera una sola fila con los botones `💾 Salvar` y `❌ Salir`.
+- `buildSaveBackExitKeyboard()` genera el teclado estándar con `💾 Salvar`, `🔙 Volver` y `❌ Salir` en dos filas para mantener la escena abierta.
 - `sendReportWithKb(ctx, pages, kb)` envía cada página del reporte y luego un mensaje
   final con esos botones.
 - Los asistentes deben enviar primero el reporte y **después** un mensaje con el teclado;
@@ -13,3 +14,4 @@
 - El reporte se arma con HTML plano (sin `<br>`/`<ul>`) y se envía con `sendLargeMessage` en `parse_mode: 'HTML'`.
 - El análisis calcula necesidad = |deudas| + colchón − activos, determina la venta objetivo/instantánea a la tasa SELL y clasifica urgencia 🔴/🟠/🟢 según inventario disponible.
 - Cuando el inventario USD no alcanza el mínimo configurado se muestra la alerta “⚠️ inventario menor al mínimo…”, y se omite cualquier sugerencia de ciclos de compra.
+- El informe expone ahora la tasa de compra proveniente de `moneda.tasa_usd`, la tasa de venta configurada y las equivalencias en USD para Activos y Neto usando esa tasa de compra.

--- a/commands/monitor_assist.js
+++ b/commands/monitor_assist.js
@@ -28,7 +28,7 @@ const {
   editIfChanged,
   buildBackExitRow,
   arrangeInlineButtons,
-  buildSaveExitRow,
+  buildSaveBackExitKeyboard,
   sendReportWithKb,
 } = require('../helpers/ui');
 const pool = require('../psql/db.js');
@@ -257,7 +257,7 @@ const monitorAssist = new Scenes.WizardScene(
           await editIfChanged(ctx, 'Generando reporte...', { parse_mode: 'HTML' });
           const msgs = await runMonitor(ctx, cmd);
           ctx.wizard.state.lastReport = msgs;
-          const kb = Markup.inlineKeyboard([buildSaveExitRow()]).reply_markup; // UX-2025
+          const kb = buildSaveBackExitKeyboard({ back: 'BACK_TO_MAIN' }); // UX-2025
           await sendReportWithKb(ctx, [], kb); // UX-2025
           ctx.wizard.state.route = 'AFTER_RUN';
           return;
@@ -355,6 +355,9 @@ const monitorAssist = new Scenes.WizardScene(
           });
           ctx.wizard.state.route = 'ASK_AGAIN';
           return;
+        }
+        if (data === 'BACK_TO_MAIN') {
+          return showMain(ctx);
         }
         break;
       case 'ASK_AGAIN':

--- a/commands/tarjetas_assist.js
+++ b/commands/tarjetas_assist.js
@@ -30,6 +30,7 @@ const {
   buildBackExitRow,
   arrangeInlineButtons,
   buildSaveExitRow,
+  buildSaveBackExitKeyboard,
   sendReportWithKb,
 } = require('../helpers/ui');
 const pool = require('../psql/db.js');
@@ -368,7 +369,7 @@ async function showAll(ctx) {
   const blocks = buildAllBlocks(ctx.wizard.state.data);
   ctx.wizard.state.lastReport = blocks; // UX-2025
   await sendLargeMessage(ctx, blocks); // UX-2025
-  const kb = Markup.inlineKeyboard([buildSaveExitRow()]).reply_markup; // UX-2025
+  const kb = buildSaveBackExitKeyboard({ back: 'BACK_TO_MENU' }); // UX-2025
   await sendReportWithKb(ctx, [], kb); // UX-2025
   ctx.wizard.state.lastRender = {};
   ctx.wizard.state.route = { view: 'AFTER_REPORT' }; // UX-2025
@@ -492,6 +493,9 @@ const tarjetasAssist = new Scenes.WizardScene(
             await sendAndLog(ctx, m);
           }
           return;
+        }
+        if (data === 'BACK_TO_MENU') {
+          return showMenu(ctx);
         }
         break; // UX-2025
       default:

--- a/helpers/ui.js
+++ b/helpers/ui.js
@@ -68,6 +68,14 @@ function buildSaveExitRow(save = 'SAVE', exit = 'EXIT') {
   ];
 }
 
+// UX-2025: teclado estándar con guardar, volver y salir en dos filas
+function buildSaveBackExitKeyboard({ save = 'SAVE', back = 'BACK', exit = 'EXIT' } = {}) {
+  return Markup.inlineKeyboard([
+    [Markup.button.callback('💾 Salvar', save), Markup.button.callback('🔙 Volver', back)],
+    [Markup.button.callback('❌ Salir', exit)],
+  ]);
+}
+
 /**
  * Construye un teclado estándar con controles de paginación.
  *
@@ -118,13 +126,15 @@ function arrangeInlineButtons(buttons = []) {
 }
 
 // UX-2025: envía páginas y agrega teclado de acción al final
-async function sendReportWithKb(ctx, pages = [], kbInline) {
+async function sendReportWithKb(ctx, pages = [], kbInline, { message } = {}) {
   for (const p of pages) {
     await ctx.reply(p, { parse_mode: 'HTML' });
   }
   const extra = { parse_mode: 'HTML' };
-  if (kbInline) extra.reply_markup = kbInline;
-  await ctx.reply('Reporte generado.\nSelecciona una acción:', extra);
+  if (kbInline) {
+    extra.reply_markup = kbInline.reply_markup || kbInline;
+  }
+  await ctx.reply(message || 'Reporte generado.\nSelecciona una acción:', extra);
 }
 module.exports = {
   editIfChanged,
@@ -132,5 +142,6 @@ module.exports = {
   buildBackExitRow,
   arrangeInlineButtons,
   buildSaveExitRow,
+  buildSaveBackExitKeyboard,
   sendReportWithKb,
 };

--- a/tests/__tests__/fondoAdvisor.wiring.test.js
+++ b/tests/__tests__/fondoAdvisor.wiring.test.js
@@ -75,7 +75,12 @@ describe('fondoAdvisor wiring', () => {
     expect(message).toContain('Venta requerida (Zelle)');
     expect(message).toContain('Faltante tras venta');
     expect(message).toContain('Liquidez rápida disponible');
+    expect(message).toContain('Compra (DB)');
+    expect(message).toContain('Venta (config)');
+    expect(message).toContain('Disponible ahora');
+    expect(message).not.toContain('Reservado');
     expect(result.plan.remainingCup).toBeGreaterThan(0);
     expect(result.urgency).toBe('🟠 PRIORITARIO');
+    expect(result.buyRateCup).toBe(400);
   });
 });

--- a/tests/commands/assistantsUX.test.js
+++ b/tests/commands/assistantsUX.test.js
@@ -50,8 +50,11 @@ test('monitorAssist envía teclado y no edita después', async () => {
   const last = ctx.reply.mock.calls.at(-1);
   expect(last[0]).toMatch('Reporte generado.');
   const kb = last[1].reply_markup.inline_keyboard;
-  expect(kb).toHaveLength(1);
+  expect(kb).toHaveLength(2);
   expect(kb[0]).toHaveLength(2);
+  expect(kb[0][1].text).toMatch('Volver');
+  expect(kb[1]).toHaveLength(1);
+  expect(kb[1][0].text).toMatch('Salir');
   const editOrder = ctx.telegram.editMessageText.mock.invocationCallOrder[0];
   const replyOrder = ctx.reply.mock.invocationCallOrder.slice(-1)[0];
   expect(replyOrder).toBeGreaterThan(editOrder);

--- a/tests/commands/monitor.test.js
+++ b/tests/commands/monitor.test.js
@@ -1,4 +1,9 @@
-const { parseArgs, calcRanges } = require('../../commands/monitor');
+jest.mock('../../psql/db.js', () => ({
+  query: jest.fn(),
+}));
+
+const { query } = require('../../psql/db.js');
+const { parseArgs, calcRanges, getSellRate } = require('../../commands/monitor');
 const moment = require('moment-timezone');
 
 describe('parseArgs', () => {
@@ -26,5 +31,32 @@ describe('calcRanges', () => {
     const { start, end } = calcRanges('mes', 'UTC', null, '2024-02');
     expect(moment.tz(start, 'UTC').format('YYYY-MM')).toBe('2024-02');
     expect(moment.tz(end, 'UTC').format('YYYY-MM')).toBe('2024-02');
+  });
+});
+
+describe('getSellRate', () => {
+  beforeEach(() => {
+    query.mockReset();
+  });
+
+  afterEach(() => {
+    delete process.env.ADVISOR_SELL_RATE_CUP_PER_USD;
+    delete process.env.ADVISOR_SELL_FEE_PCT;
+    delete process.env.ADVISOR_FX_MARGIN_PCT;
+  });
+
+  test('usa tasa de compra de la DB sin invertirla', async () => {
+    process.env.ADVISOR_SELL_RATE_CUP_PER_USD = '459';
+    process.env.ADVISOR_SELL_FEE_PCT = '0.02';
+    process.env.ADVISOR_FX_MARGIN_PCT = '0';
+    query.mockResolvedValue({ rows: [{ tasa_usd: 400 }] });
+
+    const info = await getSellRate();
+
+    expect(info.buyRate).toBe(400);
+    expect(info.buySource).toBe('db');
+    expect(info.sellRate).toBe(459);
+    expect(info.source).toBe('env');
+    expect(info.sellNet).toBe(449);
   });
 });


### PR DESCRIPTION
## Summary
- surface the CUP buy rate from the database in the fondo advisor report, add USD equivalents for activos/neto, and drop reserve wording
- keep the sell rate from configuration, adjust monitor rate fetching, and document the new behavior
- add a reusable save/back/exit keyboard and update the tarjetas/monitor assistants plus tests to restore in-scene navigation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d18e66188c832da5ec73af3e02262b