### PR TITLE
chore(fondoAdvisor): mostrar USD en Liquidez y limpiar bloques redundantes

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ puede ejecutarse manualmente mediante el comando `/fondo`. El análisis:
 - Calcula la necesidad en CUP con `necesidad = |deudas| + colchón - activos`, permite configurar el colchón objetivo y deriva la venta objetivo/instantánea en USD con redondeos enteros.
 - Lee la tasa SELL desde la tabla `moneda` (código `CUP`) y usa las variables `ADVISOR_*` como fallback.
 - Ignora como liquidez las cuentas por cobrar cuyo banco/agente/número contenga "debe/deuda/deudor".
+- El bloque 🏦 <b>Liquidez rápida disponible</b> muestra el equivalente aproximado en USD por banco usando la tasa de compra almacenada en la base de datos.
 - Muestra un bloque 💵 <b>Inventario USD/Zelle</b> con Total, Reservado (`ADVISOR_MIN_KEEP_USD`) y Usable ahora; el inventario USD y Zelle es 1 × 1 y si el usable cae por debajo de `ADVISOR_MIN_SELL_USD` se marca con ⚠️.
 - Ajusta la severidad del encabezado según la necesidad en CUP y la cobertura real con el inventario USD y la capacidad de depósito: muestra 🔴/🟠/🟡 cuando hay necesidad pendiente, dejando 🟢 solo si `needCup <= 0`.
 - Evalúa los límites mensuales sumando las SALIDAS (`importe < 0`) del mes por tarjeta CUP, muestra el tope activo en la línea ℹ️ y renderiza una tabla monoespaciada dentro de `<pre>` con columnas Banco, Tarjeta (`#1234`), `SAL`, `SALDO`, `LIBRE`, `CAP` y Estado (🟥 BLOCKED, 🟡 EXTENDABLE, 🟢 OK), incluyendo una fila TOTAL con los agregados. El `CAP` aplica `max(0, (límite − salidas) − saldo_actual_positivo)` y MITRANSFER/BOLSA nunca aparece en esa tabla.

--- a/TODOs.md
+++ b/TODOs.md
@@ -11,3 +11,4 @@
 - Investigar recordatorios cuando exista faltante en CUP tras la venta inmediata.
 - Analizar UI para permitir modificar el colchón objetivo directamente desde el comando `/fondo`.
 - Revisar alertas cuando la capacidad real (`CAP`) llegue a cero en varias tarjetas seguidas.
+- ✅ Liquidez rápida disponible muestra equivalentes USD por banco usando la tasa de compra.

--- a/agent.md
+++ b/agent.md
@@ -15,3 +15,4 @@
 - El análisis calcula necesidad = |deudas| + colchón − activos, determina la venta objetivo/instantánea a la tasa SELL y clasifica urgencia 🔴/🟠/🟢 según inventario disponible.
 - Cuando el inventario USD no alcanza el mínimo configurado se muestra la alerta “⚠️ inventario menor al mínimo…”, y se omite cualquier sugerencia de ciclos de compra.
 - El informe expone ahora la tasa de compra proveniente de `moneda.tasa_usd`, la tasa de venta configurada y las equivalencias en USD para Activos y Neto usando esa tasa de compra.
+- La sección 🏦 Liquidez rápida disponible añade el equivalente en USD por banco cuando hay tasa de compra válida; si no, conserva solo los montos en CUP.

--- a/tests/__tests__/fondoAdvisor.calc.test.js
+++ b/tests/__tests__/fondoAdvisor.calc.test.js
@@ -101,7 +101,7 @@ describe('fondoAdvisor pure calculations', () => {
       { moneda: 'CUP', banco: 'BANDEC', agente: 'Cliente Deudor', numero: 'Cuenta deuda', saldo: -5000, tasa_usd: 1 },
       { moneda: 'CUP', banco: 'BANDEC', agente: 'Pago debe', numero: 'Por cobrar', saldo: 10000, tasa_usd: 1 },
       { moneda: 'USD', banco: 'BANDEC', agente: 'Caja fuerte', numero: '1111', saldo: 900, tasa_usd: 1 },
-      { moneda: 'MLC', banco: 'BPA', agente: 'Caja fuerte', numero: '2222', saldo: 45200, tasa_usd: 452 },
+      { moneda: 'MLC', banco: 'BPA', agente: 'Caja fuerte', numero: '2222', saldo: 45200, tasa_usd: 1 / 452 },
     ];
 
     const totals = aggregateBalances(rows, ['BANDEC', 'BPA']);

--- a/tests/__tests__/fondoAdvisor.test.js
+++ b/tests/__tests__/fondoAdvisor.test.js
@@ -61,7 +61,7 @@ describe('fondoAdvisor core calculations', () => {
         agente: 'Caja fuerte',
         numero: '2222',
         saldo: 45200,
-        tasa_usd: 452,
+        tasa_usd: 1 / 452,
       },
     ];
     const totals = aggregateBalances(rows, ['BANDEC', 'BPA']);

--- a/tests/__tests__/fondoAdvisor.wiring.test.js
+++ b/tests/__tests__/fondoAdvisor.wiring.test.js
@@ -75,8 +75,9 @@ describe('fondoAdvisor wiring', () => {
     expect(message).toContain('Venta requerida (Zelle)');
     expect(message).toContain('Faltante tras venta');
     expect(message).toContain('Liquidez rápida disponible');
-    expect(message).toContain('Compra (DB)');
-    expect(message).toContain('Venta (config)');
+    expect(message).toContain('BANDEC: 100,000 CUP (≈ 250.00 USD)');
+    expect(message).not.toContain('Compra (DB)');
+    expect(message).not.toContain('@ compra');
     expect(message).toContain('Disponible ahora');
     expect(message).not.toContain('Reservado');
     expect(result.plan.remainingCup).toBeGreaterThan(0);

--- a/tests/__tests__/middlewares/__snapshots__/fondoAdvisor.renderAdvice.test.js.snap
+++ b/tests/__tests__/middlewares/__snapshots__/fondoAdvisor.renderAdvice.test.js.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`renderAdvice output formatting snapshot completo mantiene formato HTML de liquidez 1`] = `
+"🧮 <b>Asesor de Fondo</b>
+
+🔴 URGENTE
+
+━━━━━━━━━━━━━━━━━━
+
+📊 <b>Estado actual CUP</b>
+• Activos: 412,779 CUP (≈ 1,031.95 USD)
+• Deudas: -275,000 CUP
+• Neto: 137,779 CUP (≈ 344.45 USD)
+• Libre tras deudas: 137,779 CUP
+
+🎯 <b>Objetivo</b>
+• Colchón objetivo: 180,000 CUP
+• Necesidad adicional: 42,221 CUP
+
+💵 <b>Inventario USD/Zelle</b>
+• Total: 180 USD
+• Disponible ahora: 180 USD
+
+💸 <b>Venta requerida (Zelle)</b>
+• Objetivo: vender 94 USD a 452 ⇒ +42,488 CUP
+• Vende ahora: 80 USD ⇒ +36,160 CUP
+• Faltante tras venta: 6,061 CUP (≈ 14 USD)
+
+────────────────────────────────
+
+🚦 <b>Límite mensual por tarjeta</b>
+
+ℹ️ Límite mensual: Estándar 120,000 CUP • BPA 120,000 CUP (ampliable)
+
+<pre>—</pre>
+
+📍 <b>Sugerencia de destino del CUP</b>
+
+<pre>Venta AHORA: 36,160 CUP
+  Sin capacidad disponible
+Objetivo total: 42,488 CUP
+  Sin capacidad disponible
+  ⚠️ CUP sin destino: 6,061 CUP</pre>
+
+────────────────────────────────
+
+🧾 <b>Proyección post-venta</b>
+• Negativos: 0 CUP
+• Colchón proyectado: 173,939 CUP &lt; 180,000
+
+🏦 <b>Liquidez rápida disponible</b>
+• BANDEC: 322,491 CUP (≈ 806.23 USD)
+• MITRANSFER: 53,628 CUP (≈ 134.07 USD)
+• METRO: 23,295 CUP (≈ 58.24 USD)
+• BPA: 13,365 CUP (≈ 33.41 USD)
+
+📐 <b>Explicación</b>
+• Fórmula: necesidad = |deudas| + colchón − activos = 275,000 + 180,000 − 412,779 = 42,221 CUP
+• Objetivo USD = ceil(necesidad / sellNet) (+ márgenes y redondeo)
+• sellNet = floor(SELL × (1 − fee)) ⇒ SELL: 452 (fuente ENV)  fee: 0.00%"
+`;

--- a/tests/__tests__/middlewares/fondoAdvisor.renderAdvice.test.js
+++ b/tests/__tests__/middlewares/fondoAdvisor.renderAdvice.test.js
@@ -1,0 +1,151 @@
+'use strict';
+
+const { renderAdvice } = require('../../../middlewares/fondoAdvisor');
+
+function buildBaseResult(overrides = {}) {
+  const baseConfig = {
+    cushion: 180000,
+    sellRate: 452,
+    minSellUsd: 40,
+    liquidityBanks: ['BANDEC', 'MITRANSFER', 'METRO', 'BPA'],
+    sellFeePct: 0,
+    fxMarginPct: 0,
+    sellRoundToUsd: 1,
+    minKeepUsd: 0,
+    limitMonthlyDefaultCup: 120000,
+    limitMonthlyBpaCup: 120000,
+    extendableBanks: ['BPA'],
+    allocationBankOrder: ['BANDEC', 'MITRANSFER', 'METRO', 'BPA'],
+  };
+
+  const base = {
+    activosCup: 412779,
+    deudasCup: -275000,
+    netoCup: 137779,
+    cushionTarget: 180000,
+    needCup: 42221,
+    disponibles: 137779,
+    plan: {
+      sellTarget: { usd: 94, cupIn: 42488 },
+      sellNow: { usd: 80, cupIn: 36160 },
+      remainingCup: 6061,
+      remainingUsd: 14,
+      sellNet: 452,
+    },
+    projection: { negativosPost: 0, colchonPost: 173939 },
+    liquidityByBank: {
+      BANDEC: 322491,
+      MITRANSFER: 53628,
+      METRO: 23295,
+      BPA: 13365,
+    },
+    config: baseConfig,
+    deudaAbs: 275000,
+    urgency: '🟠 PRIORITARIO',
+    monthlyLimits: { cards: [], totals: { totalRemaining: 0, blocked: 0, extendable: 0 } },
+    distributionNow: { assignments: [], leftover: 0, totalAssigned: 0 },
+    distributionTarget: { assignments: [], leftover: 6061, totalAssigned: 0 },
+    buyRateCup: 400,
+    buyRateSource: 'db',
+    sellRateSource: 'env',
+    usdInventory: 180,
+  };
+
+  const merged = {
+    ...base,
+    ...overrides,
+  };
+
+  merged.plan = {
+    ...base.plan,
+    ...(overrides.plan || {}),
+  };
+
+  merged.projection = {
+    ...base.projection,
+    ...(overrides.projection || {}),
+  };
+
+  merged.config = {
+    ...baseConfig,
+    ...(overrides.config || {}),
+  };
+
+  merged.liquidityByBank = {
+    ...base.liquidityByBank,
+    ...(overrides.liquidityByBank || {}),
+  };
+
+  const overridesMonthly = overrides.monthlyLimits || {};
+  merged.monthlyLimits = {
+    cards: Array.isArray(overridesMonthly.cards) ? overridesMonthly.cards : base.monthlyLimits.cards,
+    totals: {
+      ...base.monthlyLimits.totals,
+      ...(overridesMonthly.totals || {}),
+    },
+  };
+
+  merged.distributionNow = {
+    ...base.distributionNow,
+    ...(overrides.distributionNow || {}),
+  };
+
+  merged.distributionTarget = overrides.hasOwnProperty('distributionTarget')
+    ? overrides.distributionTarget
+    : base.distributionTarget;
+
+  return merged;
+}
+
+beforeEach(() => {
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('renderAdvice output formatting', () => {
+  test('liquidez rápida muestra equivalentes en USD cuando hay tasa de compra', () => {
+    const result = buildBaseResult();
+    const blocks = renderAdvice(result);
+    const liquidityBlock = blocks.find((b) => b.startsWith('🏦 <b>Liquidez rápida disponible</b>'));
+    expect(liquidityBlock).toBeDefined();
+    expect(liquidityBlock).toContain('• BANDEC: 322,491 CUP (≈ 806.23 USD)');
+    expect(liquidityBlock).toContain('• MITRANSFER: 53,628 CUP (≈ 134.07 USD)');
+    expect(liquidityBlock).toContain('• METRO: 23,295 CUP (≈ 58.24 USD)');
+    expect(liquidityBlock).toContain('• BPA: 13,365 CUP (≈ 33.41 USD)');
+  });
+
+  test('estado actual elimina sufijo de tasa de compra en equivalentes USD', () => {
+    const result = buildBaseResult();
+    const message = renderAdvice(result).join('\n\n');
+    expect(message).toContain('📊 <b>Estado actual CUP</b>');
+    expect(message).not.toContain('@ compra');
+  });
+
+  test('se eliminan bloques de tasas, equivalencias y parámetros', () => {
+    const result = buildBaseResult();
+    const message = renderAdvice(result).join('\n\n');
+    expect(message).not.toContain('💱 <b>Tasas de referencia</b>');
+    expect(message).not.toContain('🔄 <b>Equivalencias de referencia</b>');
+    expect(message).not.toContain('📝 <b>Parámetros</b>');
+  });
+
+  test('snapshot completo mantiene formato HTML de liquidez', () => {
+    const result = buildBaseResult();
+    const message = renderAdvice(result).join('\n\n');
+    expect(message).toMatchSnapshot();
+  });
+
+  test('liquidez rápida se mantiene solo en CUP cuando no hay tasa válida', () => {
+    const result = buildBaseResult({ buyRateCup: null, buyRateSource: 'none' });
+    const liquidityBlock = renderAdvice(result).find((b) =>
+      b.startsWith('🏦 <b>Liquidez rápida disponible</b>')
+    );
+    expect(liquidityBlock).toBeDefined();
+    expect(liquidityBlock).toContain('• BANDEC: 322,491 CUP');
+    expect(liquidityBlock).not.toContain('USD');
+  });
+});


### PR DESCRIPTION
## Summary
- eliminate the "@ compra" suffix in Estado actual CUP while keeping USD equivalents sourced from the configured buy rate
- append per-bank USD approximations in the Liquidez rápida disponible block and add focused debug logs around rate usage
- remove outdated tasas/equivalencias/parámetros blocks and add Jest coverage with targeted assertions and snapshots for renderAdvice

## Testing
- `npm test -- --silent`
- `npx jest --runInBand --coverage --silent`


------
https://chatgpt.com/codex/tasks/task_e_68d1c120c66c832d97d7e99589defb0a