### PR TITLE
Send saldo summaries to private chats from groups

### DIFF
--- a/tests/helpers/sessionSummary.test.js
+++ b/tests/helpers/sessionSummary.test.js
@@ -36,18 +36,25 @@ test('flushOnExit reports total, day and last deltas', async () => {
   const sent = [];
   const ctx = {
     from: { id: 1, username: 'tester', first_name: 'Test' },
-    chat: { id: 99, type: 'private' },
+    chat: { id: -99, type: 'supergroup' },
     telegram: {
       sendMessage: async (id, html) => {
-        sent.push(html);
+        sent.push({ id, html });
       },
     },
+    reply: jest.fn().mockResolvedValue(null),
   };
 
   await flushOnExit(ctx);
 
   expect(sent.length).toBe(4);
-  expect(sent[1]).toMatch(/30\.00.*80\.00.*\+50\.00/);
-  expect(sent[2]).toMatch(/50\.00.*80\.00.*\+30\.00/);
-  expect(sent[3]).toMatch(/60\.00.*80\.00.*\+20\.00/);
+  sent.forEach((msg) => {
+    expect(msg.id).toBe(1);
+  });
+  expect(sent[1].html).toMatch(/30\.00.*80\.00.*\+50\.00/);
+  expect(sent[2].html).toMatch(/50\.00.*80\.00.*\+30\.00/);
+  expect(sent[3].html).toMatch(/60\.00.*80\.00.*\+20\.00/);
+  expect(ctx.reply).toHaveBeenCalled();
+  const [notice] = ctx.reply.mock.calls[0];
+  expect(notice).toContain('Resumen de cambios enviado por privado');
 });

--- a/tests/middlewares/fondoAdvisor.private.test.js
+++ b/tests/middlewares/fondoAdvisor.private.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const { runFondo } = require('../../middlewares/fondoAdvisor');
+const seedMinimal = require('../seedMinimal');
+
+test('runFondo envía el resumen al privado cuando se ejecuta desde un grupo', async () => {
+  await seedMinimal();
+
+  const ctx = {
+    session: {},
+    from: { id: 123, username: 'tester' },
+    chat: { id: -456, type: 'supergroup' },
+    telegram: {
+      sendMessage: jest.fn().mockResolvedValue({}),
+    },
+    reply: jest.fn().mockResolvedValue({}),
+  };
+
+  await runFondo(ctx, {
+    skipSellRateFetch: true,
+    balances: [
+      {
+        moneda: 'CUP',
+        banco: 'BANDEC',
+        agente: 'AG',
+        numero: '0001',
+        saldo: 100000,
+        tasa_usd: 0.01,
+      },
+    ],
+    config: {
+      cushion: 50000,
+      sellRate: 450,
+      minSellUsd: 40,
+      liquidityBanks: ['BANDEC'],
+    },
+  });
+
+  const recipients = ctx.telegram.sendMessage.mock.calls.map((call) => call[0]);
+  expect(recipients.every((id) => id === ctx.from.id)).toBe(true);
+  expect(ctx.reply).toHaveBeenCalled();
+  const [notice] = ctx.reply.mock.calls[0];
+  expect(notice).toContain('resumen del fondo por privado');
+});


### PR DESCRIPTION
## Summary
- route saldo session summaries to the actor's privado when the wizard runs inside a group and leave a short notice in the chat
- deliver fondoAdvisor analyses via DM for group contexts, falling back to the group only if the private send fails
- add regression tests that cover the new private-delivery flows for saldo summaries and fondoAdvisor

## Testing
- npm test
- npx jest --runInBand --coverage

------
https://chatgpt.com/codex/tasks/task_e_68d225d52eb0832db9857384ebd20b1e