### PR TITLE
Evitar spam del asesor de fondo en grupos

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ monitor o extracto (hook en el evento `leave`). El asistente de `/saldo` dispara
 `leaveMiddleware` para garantizar que, incluso si no se registra el middleware global, se envíe el reporte al finalizar. Además
 puede ejecutarse manualmente mediante el comando `/fondo`. El análisis:
 
+- En chats de grupo o supergrupo el análisis ya no se publica en el canal: se intenta enviarlo por mensaje directo a la persona
+  operadora; si no es posible, se omite sin mostrar errores en el grupo.
+
 - Calcula la necesidad en CUP con `necesidad = |deudas| + colchón - activos`, permite configurar el colchón objetivo y deriva la venta objetivo/instantánea en USD con redondeos enteros.
 - Lee la tasa SELL desde la tabla `moneda` (código `CUP`) y usa las variables `ADVISOR_*` como fallback.
 - Ignora como liquidez las cuentas por cobrar cuyo banco/agente/número contenga "debe/deuda/deudor".

--- a/TODOs.md
+++ b/TODOs.md
@@ -6,6 +6,7 @@
 
 ## Asesor de Fondo
 
+- ✅ Evitar spam en grupos enviando el análisis por DM cuando se cierra un asistente.
 - Definir alertas automáticas cuando la urgencia 🔴 se repita en días consecutivos.
 - Evaluar ajustes del mínimo USD por operación según disponibilidad real de inventario.
 - Investigar recordatorios cuando exista faltante en CUP tras la venta inmediata.

--- a/agent.md
+++ b/agent.md
@@ -11,6 +11,7 @@
 
 - El asistente de `/saldo` llama a `runFondo(ctx)` desde su `leaveMiddleware`; los asistentes de tarjetas/monitor/extracto lo
   hacen mediante el hook global en `registerFondoAdvisor` (usa `setImmediate` para esperar la persistencia de saldos).
+- En grupos/supergrupos el informe se envía por DM al operador; si no es posible abrir chat, se omite para evitar spam.
 - El reporte se arma con HTML plano (sin `<br>`/`<ul>`) y se envía con `sendLargeMessage` en `parse_mode: 'HTML'`.
 - El análisis calcula necesidad = |deudas| + colchón − activos, determina la venta objetivo/instantánea a la tasa SELL y clasifica urgencia 🔴/🟠/🟢 según inventario disponible.
 - Cuando el inventario USD no alcanza el mínimo configurado se muestra la alerta “⚠️ inventario menor al mínimo…”, y se omite cualquier sugerencia de ciclos de compra.

--- a/tests/commands/saldo.leave.test.js
+++ b/tests/commands/saldo.leave.test.js
@@ -9,15 +9,81 @@ const saldoWizard = require('../../commands/saldo');
 
 describe('saldo wizard leave hook', () => {
   beforeEach(() => {
-    runFondo.mockClear();
+    runFondo.mockReset();
   });
 
-  it('ejecuta el análisis de fondo al abandonar el asistente', async () => {
-    const ctx = { wizard: { state: { foo: 'bar' } }, session: {} };
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('envía el análisis por DM cuando el asistente se cierra en un grupo', async () => {
+    const sendMessage = jest.fn().mockResolvedValue();
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    runFondo.mockImplementation(async (ctxArg, opts) => {
+      expect(opts).toBeDefined();
+      expect(typeof opts.send).toBe('function');
+      await opts.send('<b>análisis</b>');
+    });
+
+    const ctx = {
+      wizard: { state: { foo: 'bar' } },
+      session: {},
+      chat: { type: 'supergroup', id: -100 },
+      from: { id: 123 },
+      telegram: { sendMessage },
+    };
 
     await saldoWizard.handleSaldoLeave(ctx);
 
     expect(ctx.wizard.state).toEqual({});
+    expect(runFondo).toHaveBeenCalledTimes(1);
+    expect(runFondo).toHaveBeenCalledWith(
+      ctx,
+      expect.objectContaining({ send: expect.any(Function) })
+    );
+    expect(sendMessage).toHaveBeenCalledWith(123, '<b>análisis</b>', {
+      parse_mode: 'HTML',
+    });
+    expect(logSpy).toHaveBeenCalledWith('[SALDO_WIZ] fondoAdvisor enviado por DM a', 123);
+  });
+
+  it('omite el envío al grupo si el DM falla', async () => {
+    const error = Object.assign(new Error('403: Forbidden'), { code: 403 });
+    const sendMessage = jest.fn().mockRejectedValue(error);
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    runFondo.mockImplementation(async (ctxArg, opts) => {
+      await opts.send('reporte');
+    });
+
+    const ctx = {
+      wizard: { state: { foo: 'bar' } },
+      session: {},
+      chat: { type: 'group', id: -200 },
+      from: { id: 987 },
+      telegram: { sendMessage },
+    };
+
+    await expect(saldoWizard.handleSaldoLeave(ctx)).resolves.toBeUndefined();
+
+    expect(runFondo).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(
+      '[SALDO_WIZ] No se pudo enviar DM del fondoAdvisor:',
+      error.message
+    );
+  });
+
+  it('mantiene el envío en el chat privado', async () => {
+    runFondo.mockResolvedValue(null);
+    const ctx = {
+      wizard: { state: { foo: 'bar' } },
+      session: {},
+      chat: { type: 'private', id: 555 },
+      telegram: { sendMessage: jest.fn() },
+    };
+
+    await saldoWizard.handleSaldoLeave(ctx);
+
     expect(runFondo).toHaveBeenCalledTimes(1);
     expect(runFondo).toHaveBeenCalledWith(ctx);
   });


### PR DESCRIPTION
## Summary
- envía el informe del asesor de fondo por DM cuando /saldo finaliza en grupos, evitando publicar el bloque largo en el chat grupal
- replica el envío por DM para los hooks automáticos del asesor de fondo al salir de otras escenas
- documenta el nuevo comportamiento y amplía las pruebas unitarias cubriendo grupos, errores de DM y wiring

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d22a70eb4c832da053ea63a2fb7606