### PR TITLE
Add command reference documentation and fondo audit

### DIFF
--- a/docs/auditorias/fondo-vs-tarjetas.md
+++ b/docs/auditorias/fondo-vs-tarjetas.md
@@ -1,0 +1,23 @@
+# Auditoría: diferencias entre /fondo y /tarjetas
+
+## Resumen ejecutivo
+- `/fondo` toma los últimos saldos de todas las tarjetas, calcula la liquidez utilizable en CUP y recomienda acciones de venta o cobertura. Filtra cuentas etiquetadas como deudas y solo suma activos positivos en CUP que pertenezcan a bancos de liquidez configurados.【F:middlewares/fondoAdvisor.js†L496-L618】【F:middlewares/fondoAdvisor.js†L1094-L1215】
+- `/tarjetas` lista los últimos movimientos sin filtrar, agrupando por moneda, banco y agente; reporta tanto saldos positivos como negativos y convierte cada monto a USD con la tasa guardada en la tarjeta.【F:commands/tarjetas.js†L25-L200】
+
+## Fuentes de datos
+- Ambos comandos consultan el último movimiento por tarjeta mediante un `JOIN` lateral sobre `movimiento`, pero `/fondo` solo conserva los campos esenciales para agregación (moneda, banco, agente, número, tasa y saldo).【F:middlewares/fondoAdvisor.js†L496-L516】
+- `/tarjetas` recupera metadatos adicionales —emojis, descripción y fecha del último movimiento— para mostrarlos en la interfaz y construir resúmenes por moneda y agente.【F:commands/tarjetas.js†L25-L133】
+
+## Reglas de agregación
+- `/fondo` ignora saldos negativos al sumar activos CUP y traslada los negativos a la métrica `deudas`. También excluye cualquier tarjeta cuyo agente, banco o número coincida con la expresión regular `(debe|deuda|deudas|deudor)` para evitar contar cuentas por cobrar como liquidez.【F:middlewares/fondoAdvisor.js†L543-L606】
+- Al calcular inventario en USD, `/fondo` solo incluye tarjetas etiquetadas como USD o MLC y multiplica el saldo por `tasa_usd`.【F:middlewares/fondoAdvisor.js†L606-L612】
+- `/tarjetas` no aplica filtros: acumula saldos iniciales y finales por moneda y banco, registra el delta de cada tarjeta y calcula equivalentes en USD directamente en los bloques de salida.【F:commands/tarjetas.js†L60-L200】
+
+## Salida y notificaciones
+- `/fondo` construye bloques con métricas de liquidez, necesidades de CUP, plan de venta, límites mensuales y proyección posterior. Si el comando se lanza en un grupo, reenvía el resultado por mensaje privado al usuario para evitar spam.【F:middlewares/fondoAdvisor.js†L1183-L1321】
+- `/tarjetas` genera múltiples bloques con resúmenes globales, detalle por moneda y tarjetas por agente y envía el resultado usando `sendLargeMessage` directamente en el chat origen.【F:commands/tarjetas.js†L135-L209】
+
+## Recomendaciones de control
+1. Mantener sincronizada la lista de bancos líquidos (`liquidityBanks`) para que `/fondo` considere todos los canales de liquidez válidos.【F:middlewares/fondoAdvisor.js†L543-L582】【F:middlewares/fondoAdvisor.js†L1094-L1110】
+2. Revisar periódicamente los registros `[fondoAdvisor] Excluida fila…` para detectar tarjetas clasificadas como deudas y ajustar su nomenclatura si deben contarse como activos.【F:middlewares/fondoAdvisor.js†L572-L604】
+3. Cuando se investiguen discrepancias, comparar el total USD de `/tarjetas` con el inventario USD reportado por `/fondo` para confirmar que la tasa `tasa_usd` está actualizada en ambas vistas.【F:middlewares/fondoAdvisor.js†L606-L612】【F:commands/tarjetas.js†L102-L200】

--- a/docs/commands/acceso_assist.md
+++ b/docs/commands/acceso_assist.md
@@ -1,0 +1,19 @@
+# /acceso (asistente)
+
+## Descripción
+Asistente interactivo basado en escenas de Telegraf para gestionar la tabla de usuarios autorizados. Permite listar, agregar y eliminar identificadores de Telegram con acceso al bot, actualizando el mensaje en sitio para evitar duplicados y manteniendo formato HTML seguro.【F:commands/acceso_assist.js†L1-L125】
+
+## Flujo principal
+1. La primera escena responde con “Cargando…” y guarda el `message_id` para ediciones posteriores; a continuación muestra la lista actual de usuarios con botones para eliminar, añadir o salir.【F:commands/acceso_assist.js†L84-L100】
+2. Al pulsar “➕” cambia la ruta interna a `ADD` y solicita el ID del usuario mediante un mensaje editado con teclado inline de salida.【F:commands/acceso_assist.js†L95-L101】
+3. Los botones de la lista disparan eliminaciones inmediatas usando `eliminarUsuario`, mientras que introducir un ID nuevo ejecuta `agregarUsuario` tras verificar duplicados con `usuarioExiste`. Luego se recarga la lista para reflejar cambios.【F:commands/acceso_assist.js†L103-L121】
+4. El botón “Salir” edita el mensaje original con un aviso de cancelación y abandona la escena; el helper `wantExit` centraliza la lógica de cierre.【F:commands/acceso_assist.js†L28-L41】【F:commands/acceso_assist.js†L97-L101】
+
+## Entradas relevantes
+- Identificadores numéricos de Telegram ingresados manualmente por el operador o seleccionados en botones inline.【F:commands/acceso_assist.js†L95-L121】
+
+## Salidas
+- Mensajes HTML actualizados con listados de usuarios y confirmaciones de alta/baja, evitando enviar mensajes adicionales gracias a `editIfChanged`.【F:commands/acceso_assist.js†L65-L79】【F:commands/acceso_assist.js†L95-L121】
+
+## Dependencias
+- Reutiliza los helpers `agregarUsuario`, `eliminarUsuario`, `usuarioExiste` y `listarUsuarios` para operar sobre la tabla `usuarios`.【F:commands/acceso_assist.js†L16-L21】

--- a/docs/commands/agentes.md
+++ b/docs/commands/agentes.md
@@ -1,0 +1,20 @@
+# /agentes
+
+## Descripción
+Registra un conjunto de escenas para gestionar agentes (titulares) de tarjetas: listar existentes, crear nuevos, editar datos y eliminar registros junto con sus tarjetas asociadas cuando procede.【F:commands/agente.js†L1-L166】
+
+## Flujo principal
+1. El comando `/agentes` consulta la tabla `agente`, muestra la lista con botones de edición/eliminación y ofrece la opción de añadir uno nuevo.【F:commands/agente.js†L94-L123】
+2. El wizard `AGENTE_CREATE_WIZ` solicita nombre y crea el agente mediante `INSERT ... ON CONFLICT DO NOTHING`, confirmando al usuario el resultado.【F:commands/agente.js†L34-L78】
+3. El wizard `AGENTE_EDIT_WIZ` carga el agente seleccionado, permite modificar nombre y guarda los cambios gestionando colisiones por unicidad.【F:commands/agente.js†L80-L136】
+4. Al eliminar se verifican dependencias (tarjetas y movimientos) para advertir al operador y, tras confirmación, se borran tarjetas relacionadas dentro de una transacción.【F:commands/agente.js†L138-L170】
+5. Cualquier mensaje con `/cancel`, `salir` o botón `↩️ Cancelar` abandona la escena actual y notifica la cancelación.【F:commands/agente.js†L6-L32】【F:commands/agente.js†L170-L188】
+
+## Entradas relevantes
+- Textos enviados por el operador durante los wizards (`nombre` actualizado) y callbacks inline para editar o eliminar un agente específico.【F:commands/agente.js†L34-L170】
+
+## Salidas
+- Respuestas de confirmación o error según el resultado de las operaciones SQL, incluyendo advertencias cuando existen dependencias y mensajes de cancelación genéricos.【F:commands/agente.js†L44-L170】
+
+## Dependencias
+- Usa el pool PostgreSQL para `INSERT`, `UPDATE`, `DELETE` y verificaciones; se apoya en `Telegraf` (`Scenes`, `Markup`) para construir wizards y botones inline.【F:commands/agente.js†L1-L170】

--- a/docs/commands/bancos.md
+++ b/docs/commands/bancos.md
@@ -1,0 +1,20 @@
+# /bancos
+
+## Descripción
+Wizard multi-paso que permite crear, editar y eliminar bancos asociados a tarjetas, incluyendo código, nombre y emoji identificador. Gestiona botones inline para listar registros y maneja cancelaciones globales.【F:commands/banco.js†L1-L210】
+
+## Flujo principal
+1. `/bancos` lista todos los bancos registrados, muestra botones para editar/eliminar cada fila y ofrece la acción “Añadir banco”.【F:commands/banco.js†L135-L187】
+2. `BANCO_CREATE_WIZ` solicita código, nombre y emoji, guardándolos mediante `INSERT ... ON CONFLICT DO UPDATE` para permitir reusos.【F:commands/banco.js†L33-L79】
+3. `BANCO_EDIT_WIZ` precarga el banco seleccionado, permite editar código, nombre y emoji, y actualiza la fila con `UPDATE`.【F:commands/banco.js†L81-L133】
+4. Al eliminar un banco se consultan dependencias (tarjetas y movimientos) para advertir al operador; si confirma, se borran tarjetas y el banco dentro de una transacción.【F:commands/banco.js†L189-L233】
+5. El botón `↩️ Cancelar` y los comandos `/cancel`, `salir` o `/salir` cancelan el wizard actual y responden al usuario.【F:commands/banco.js†L5-L31】【F:commands/banco.js†L233-L259】
+
+## Entradas relevantes
+- Texto del operador para código/nombre/emoji durante los wizards, y callbacks inline para seleccionar registros a editar o eliminar.【F:commands/banco.js†L33-L233】
+
+## Salidas
+- Confirmaciones de creación/actualización, advertencias de dependencias y mensajes de error basados en la ejecución de las consultas SQL.【F:commands/banco.js†L61-L233】
+
+## Dependencias
+- Requiere `psql/db.js` para consultar y modificar las tablas `banco` y `tarjeta`, y utiliza componentes de Telegraf (`Scenes`, `Markup`) para construir la interfaz de wizard.【F:commands/banco.js†L1-L259】

--- a/docs/commands/comandos.md
+++ b/docs/commands/comandos.md
@@ -1,0 +1,11 @@
+# /comandos
+
+## Descripción
+Devuelve un listado estático de comandos soportados por el bot, incluyendo descripción corta, permisos sugeridos y formato de uso para cada entrada. Sirve como referencia central para la ayuda en línea.【F:commands/comandos.js†L1-L104】
+
+## Detalles
+- La estructura es un arreglo de objetos con campos `nombre`, `descripcion`, `permiso` y `uso`, utilizado por otras partes del bot para renderizar menús o respuestas de ayuda.【F:commands/comandos.js†L3-L103】
+- Incluye comandos legacy de cuentas (`crearcuenta`, `miscuentas`, `credito`, etc.) y módulos avanzados como `/tarjetas`, `/fondo`, `/monitor` y asistentes para acceso.【F:commands/comandos.js†L7-L103】
+
+## Dependencias
+- No interactúa con la base de datos; exporta un array de configuración consumido por el bot principal cuando construye menús o mensajes de ayuda.【F:commands/comandos.js†L1-L105】

--- a/docs/commands/crearcuenta.md
+++ b/docs/commands/crearcuenta.md
@@ -1,0 +1,19 @@
+# /crearcuenta
+
+## Descripción
+Crea una tabla de cuenta legacy si no existe, inicializándola con un saldo inicial opcional y un registro “Saldo inicial”. Está pensado para migraciones antiguas donde cada cuenta es una tabla separada.【F:commands/crearcuenta.js†L1-L48】
+
+## Flujo principal
+1. Extrae el nombre de la cuenta y un saldo inicial opcional (`/crearcuenta <nombre> [saldo]`).【F:commands/crearcuenta.js†L3-L4】
+2. Verifica en `pg_tables` si ya existe una tabla con ese nombre y avisa si está duplicada.【F:commands/crearcuenta.js†L7-L18】
+3. Si no existe, ejecuta `CREATE TABLE` con columnas `descripcion`, `debito`, `credito`, `total` y `fecha`, seguido de un `INSERT` del saldo inicial proporcionado.【F:commands/crearcuenta.js†L19-L37】
+4. Responde con confirmación de creación o, en caso de error SQL, envía un mensaje genérico indicando que se reintente.【F:commands/crearcuenta.js†L35-L45】
+
+## Entradas relevantes
+- Nombre de cuenta (obligatorio) y saldo inicial (opcional) proporcionados en el mensaje del usuario.【F:commands/crearcuenta.js†L3-L4】
+
+## Salidas
+- Confirmación textual con el saldo inicial aplicado, aviso de duplicado o errores de ejecución.【F:commands/crearcuenta.js†L16-L45】
+
+## Dependencias
+- Usa el pool PostgreSQL y consultas dinámicas interpolando el nombre de la tabla; requiere privilegios para crear tablas en el esquema `public`.【F:commands/crearcuenta.js†L1-L37】

--- a/docs/commands/credito.md
+++ b/docs/commands/credito.md
@@ -1,0 +1,19 @@
+# /credito
+
+## Descripción
+Registra una transacción de crédito en una cuenta legacy, sumando el monto al total acumulado de la tabla específica y almacenando una descripción libre.【F:commands/credito.js†L1-L45】
+
+## Flujo principal
+1. Espera parámetros `/credito <cuenta> <monto> <descripcion…>`; valida que existan y que el monto sea numérico.【F:commands/credito.js†L3-L17】
+2. Consulta el último total registrado en la tabla `<cuenta>` para continuar desde el saldo previo.【F:commands/credito.js†L19-L24】【F:commands/credito.js†L31-L34】
+3. Inserta una fila con la descripción, el monto como crédito y el nuevo total calculado, redondeado a dos decimales.【F:commands/credito.js†L26-L37】
+4. Informa éxito o, si la consulta falla, notifica un error genérico.【F:commands/credito.js†L38-L41】
+
+## Entradas relevantes
+- Nombre de la tabla/cuenta, monto decimal positivo y descripción textual recibidos en el mensaje del usuario.【F:commands/credito.js†L3-L28】
+
+## Salidas
+- Confirmación de la transacción o mensaje de error con instrucciones para reintentar.【F:commands/credito.js†L38-L41】
+
+## Dependencias
+- Usa el pool PostgreSQL con consultas interpoladas que apuntan a tablas legacy; requiere que la tabla exista antes de invocar el comando.【F:commands/credito.js†L1-L37】

--- a/docs/commands/cuentas.md
+++ b/docs/commands/cuentas.md
@@ -1,0 +1,18 @@
+# /miscuentas
+
+## Descripción
+Lista todas las tablas del esquema `public`, interpretándolas como cuentas legacy, y responde con un listado numerado para referencia rápida.【F:commands/cuentas.js†L1-L25】
+
+## Flujo principal
+1. Ejecuta `SELECT tablename FROM pg_tables WHERE schemaname = 'public'` para recuperar todas las tablas disponibles.【F:commands/cuentas.js†L3-L12】
+2. Convierte el resultado en una lista numerada y la envía al usuario; si no hay tablas, informa que no existen cuentas registradas.【F:commands/cuentas.js†L13-L18】
+3. En caso de error en la consulta, registra la excepción y envía un mensaje de advertencia.【F:commands/cuentas.js†L19-L22】
+
+## Entradas relevantes
+- No requiere argumentos adicionales; usa el contexto de la conexión PostgreSQL configurada en `psql/db.js`.【F:commands/cuentas.js†L1-L12】
+
+## Salidas
+- Texto con el listado de cuentas o mensajes de error cuando la consulta falla.【F:commands/cuentas.js†L13-L22】
+
+## Dependencias
+- Se apoya en el pool PostgreSQL para consultar `pg_tables` y en `ctx.reply` para enviar la respuesta al chat.【F:commands/cuentas.js†L1-L22】

--- a/docs/commands/debito.md
+++ b/docs/commands/debito.md
@@ -1,0 +1,19 @@
+# /debito
+
+## Descripción
+Registra una transacción de débito en una cuenta legacy, restando el monto del total acumulado y guardando la descripción suministrada por el usuario.【F:commands/debito.js†L1-L45】
+
+## Flujo principal
+1. Procesa parámetros `/debito <cuenta> <monto> <descripcion…>` y valida que el monto sea numérico.【F:commands/debito.js†L3-L17】
+2. Consulta el último total de la tabla `<cuenta>` y calcula el nuevo saldo restando el monto del débito.【F:commands/debito.js†L19-L35】
+3. Inserta la fila con el monto en la columna `debito`, el nuevo total y la fecha actual, redondeando a dos decimales.【F:commands/debito.js†L26-L37】
+4. Devuelve un mensaje de confirmación o reporta un error genérico si la operación falla.【F:commands/debito.js†L38-L41】
+
+## Entradas relevantes
+- Nombre de la cuenta, monto decimal y descripción provistos en el mensaje de texto.【F:commands/debito.js†L3-L37】
+
+## Salidas
+- Mensaje de éxito o advertencia sobre errores al insertar la transacción.【F:commands/debito.js†L38-L41】
+
+## Dependencias
+- Usa el pool PostgreSQL para consultar e insertar filas en la tabla legacy correspondiente.【F:commands/debito.js†L1-L37】

--- a/docs/commands/eliminarcuentas.md
+++ b/docs/commands/eliminarcuentas.md
@@ -1,0 +1,18 @@
+# /eliminarcuenta
+
+## Descripción
+Elimina una cuenta legacy representada por una tabla específica en el esquema `public`, utilizando `DROP TABLE IF EXISTS` para tolerar nombres inexistentes.【F:commands/eliminarcuentas.js†L1-L25】
+
+## Flujo principal
+1. Obtiene el nombre de la cuenta desde el mensaje (`/eliminarcuenta <nombre>`); si falta, avisa al usuario y termina.【F:commands/eliminarcuentas.js†L4-L10】
+2. Ejecuta `DROP TABLE IF EXISTS "<cuenta>"` y confirma la eliminación si la sentencia se ejecuta sin errores.【F:commands/eliminarcuentas.js†L12-L19】
+3. En caso de fallo en la consulta, registra la excepción y responde con un mensaje de advertencia.【F:commands/eliminarcuentas.js†L19-L22】
+
+## Entradas relevantes
+- Nombre de la tabla/cuenta proporcionado en el comando por el operador.【F:commands/eliminarcuentas.js†L4-L14】
+
+## Salidas
+- Mensaje de confirmación o advertencia según el resultado del `DROP TABLE`.【F:commands/eliminarcuentas.js†L17-L22】
+
+## Dependencias
+- Requiere acceso al pool PostgreSQL configurado en `psql/db.js`; las consultas se ejecutan directamente sobre la base legacy.【F:commands/eliminarcuentas.js†L1-L22】

--- a/docs/commands/extracto_assist.md
+++ b/docs/commands/extracto_assist.md
@@ -1,0 +1,19 @@
+# /extracto (asistente)
+
+## Descripción
+Wizard que guía al usuario para generar un extracto bancario filtrando por agente, moneda, banco, tarjeta y periodo. Cada pantalla reutiliza el mismo mensaje con `editIfChanged`, ofrece botón para generar informe y mantiene un encabezado con filtros actuales.【F:commands/extracto_assist.js†L1-L220】
+
+## Flujo principal
+1. Carga catálogos (agentes, bancos, monedas, tarjetas) mediante consultas parametrizadas y helpers de filtrado `buildEntityFilter` para combinar criterios seleccionados.【F:commands/extracto_assist.js†L72-L138】【F:commands/extracto_assist.js†L148-L220】
+2. Presenta menú de filtros jerárquico con opción “Generar informe” en cada paso y navegación `Anterior/Menú inicial/Salir`. Usa `smartPaginate` para dividir textos extensos antes de enviarlos.【F:commands/extracto_assist.js†L31-L199】
+3. Al ejecutar `RUN`, obtiene movimientos del periodo especificado, formatea los montos con `fmtMoney`, arma un encabezado HTML con los filtros activos y envía el extracto usando `sendReportWithKb` o `sendAndLog` según corresponda.【F:commands/extracto_assist.js†L161-L220】
+4. El asistente registra acciones en consola y permite cancelar en cualquier momento, llamando a `flushOnExit` para limpiar resúmenes pendientes.【F:commands/extracto_assist.js†L57-L68】【F:commands/extracto_assist.js†L172-L220】
+
+## Entradas relevantes
+- Selecciones realizadas a través de callbacks (`FIL_*`, `AG_*`, `MO_*`, `BK_*`, etc.) y definiciones de periodo/día/mes controladas con `moment-timezone`.【F:commands/extracto_assist.js†L13-L220】
+
+## Salidas
+- Bloques HTML paginados con encabezado y lista de movimientos, enviados en uno o varios mensajes según el tamaño del texto final.【F:commands/extracto_assist.js†L31-L220】
+
+## Dependencias
+- Utiliza helpers de UI (`editIfChanged`, `arrangeInlineButtons`, `buildBackExitRow`, `buildSaveExitRow`, `sendReportWithKb`), utilidades de formato (`fmtMoney`, `boldHeader`) y la conexión PostgreSQL para cargar tarjetas y movimientos.【F:commands/extracto_assist.js†L15-L220】

--- a/docs/commands/fondo.md
+++ b/docs/commands/fondo.md
@@ -1,0 +1,21 @@
+# /fondo
+
+## Descripción
+El comando ejecuta el asesor financiero avanzado definido en `middlewares/fondoAdvisor.js`. Calcula liquidez neta en CUP, inventario en USD y planes de venta basados en la configuración del entorno y los saldos más recientes de cada tarjeta.【F:commands/fondo.js†L1-L7】【F:middlewares/fondoAdvisor.js†L1094-L1233】
+
+## Flujo principal
+1. Carga la configuración combinando valores por defecto con variables de entorno o sobrescrituras del comando.【F:middlewares/fondoAdvisor.js†L1102-L1111】
+2. Obtiene la tasa de compra desde la base de datos (o sobrescrituras) y los saldos actuales mediante un `JOIN` lateral sobre `movimiento`.【F:middlewares/fondoAdvisor.js†L1117-L1143】【F:middlewares/fondoAdvisor.js†L496-L516】
+3. Agrega los saldos: suma CUP positivos, separa deudas y construye inventario USD con tarjetas USD/MLC, respetando exclusiones por regex y bancos líquidos configurados.【F:middlewares/fondoAdvisor.js†L543-L612】
+4. Calcula necesidades de efectivo, plan de venta y distribuciones sugeridas según límites mensuales, proyectando el estado posterior.【F:middlewares/fondoAdvisor.js†L1156-L1215】
+5. Renderiza bloques HTML y los envía por privado si el comando se ejecuta en un grupo, usando `sendLargeMessage` para respetar límites de Telegram.【F:middlewares/fondoAdvisor.js†L1183-L1321】
+
+## Entradas relevantes
+- Variables de entorno `ADVISOR_*` y límites mensuales que ajustan tasas, colchón y bancos de liquidez.【F:middlewares/fondoAdvisor.js†L367-L418】【F:middlewares/fondoAdvisor.js†L1094-L1199】
+- Saldos de tarjetas y tasa USD almacenada en la tabla `moneda`.【F:middlewares/fondoAdvisor.js†L496-L516】【F:middlewares/fondoAdvisor.js†L519-L539】
+
+## Salidas
+- Bloques con métricas de activos, deudas, urgencia y plan de acción en texto HTML, enviados mediante `sendLargeMessage` o la función `opts.send` cuando se invoca desde otros asistentes.【F:middlewares/fondoAdvisor.js†L1183-L1258】
+
+## Dependencias
+- Middleware `runFondo` es reusado por asistentes de tarjetas, monitor y extracto al abandonar sus escenas para mantener actualizado el diagnóstico financiero.【F:middlewares/fondoAdvisor.js†L1274-L1321】

--- a/docs/commands/monedas.md
+++ b/docs/commands/monedas.md
@@ -1,0 +1,19 @@
+# /monedas
+
+## Descripción
+Wizard para administrar monedas soportadas por el sistema. Permite crear nuevas monedas con código, nombre, tasa USD y emoji, así como editar o eliminar las existentes mediante botones inline.【F:commands/moneda.js†L1-L200】
+
+## Flujo principal
+1. `/monedas` lista todas las monedas registradas, ofreciendo botones para editar, eliminar o añadir nuevas cuando la tabla está vacía.【F:commands/moneda.js†L182-L207】
+2. `MONEDA_CREATE_WIZ` solicita código, nombre, unidades equivalentes a 1 USD (convertidas a `tasa_usd`) y un emoji opcional, guardando los datos con `INSERT`.【F:commands/moneda.js†L42-L107】
+3. `MONEDA_EDIT_WIZ` carga la moneda seleccionada, permite actualizar código, nombre, tasa y emoji, y persiste cambios mediante `UPDATE`.【F:commands/moneda.js†L113-L172】
+4. Los botones de eliminación piden confirmación y, al aceptar, borran la moneda de la tabla. El botón `↩️ Cancelar` y comandos `/cancel`/`salir` cierran cualquier wizard activo.【F:commands/moneda.js†L5-L37】【F:commands/moneda.js†L200-L230】
+
+## Entradas relevantes
+- Textos introducidos por el operador durante los wizards y callbacks `MONEDA_EDIT_*` / `MONEDA_DEL_*` generados desde la lista.【F:commands/moneda.js†L42-L230】
+
+## Salidas
+- Mensajes de confirmación (creada/actualizada/eliminada) o errores de validación, además de la lista formateada de monedas disponibles.【F:commands/moneda.js†L42-L230】
+
+## Dependencias
+- Utiliza el pool PostgreSQL (`psql/db.js`) para `INSERT`, `UPDATE`, `DELETE` y `SELECT`, junto con `Telegraf` (`Scenes`, `Markup`) para construir wizards y teclados inline.【F:commands/moneda.js†L1-L230】

--- a/docs/commands/monitor.md
+++ b/docs/commands/monitor.md
@@ -1,0 +1,20 @@
+# /monitor
+
+## Descripción
+Genera un monitoreo financiero comparando saldos iniciales y finales de tarjetas en un periodo configurable (día, semana, mes o año). Calcula variaciones en CUP y USD, volumen de movimientos y estados por tarjeta, agregando resultados por moneda, agente y banco.【F:commands/monitor.js†L1-L756】
+
+## Flujo principal
+1. `parseArgs` interpreta flags como `--historial`, `--solo-cambio`, `--agente`, `--banco`, `--moneda`, `--tz`, `--limite` y `--orden`, normalizando entradas con soporte para tildes y alias de periodo.【F:commands/monitor.js†L20-L120】
+2. `calcRanges` calcula el rango temporal actual y el previo según el periodo solicitado, utilizando `moment-timezone` para fijar la zona horaria por defecto en `America/Havana`.【F:commands/monitor.js†L130-L210】
+3. `SQL_BASE` consulta saldos históricos y del periodo, conteo de movimientos y volúmenes mediante varias CTE sobre la tabla `movimiento`, uniendo con `tarjeta`, `banco`, `agente` y `moneda`. Cada fila se transforma con `transformRow` para calcular deltas y equivalentes en USD.【F:commands/monitor.js†L246-L356】
+4. Aplica filtros opcionales por agente, banco o moneda mediante `buildEntityFilter`, ordena por delta/volumen/movimientos y obtiene historiales detallados cuando se usa `--historial`.【F:commands/monitor.js†L380-L720】
+5. Agrupa resultados por moneda y genera mensajes HTML con resúmenes y tablas, enviando cada bloque mediante `sendLargeMessage`. Registra advertencias cuando no se encuentran datos o filtros son ambiguos.【F:commands/monitor.js†L700-L739】
+
+## Entradas relevantes
+- Comando `/monitor [periodo]` con flags opcionales y filtros textuales; consulta la base PostgreSQL para tarjetas, movimientos, bancos y agentes.【F:commands/monitor.js†L20-L356】【F:commands/monitor.js†L380-L720】
+
+## Salidas
+- Mensajes HTML con encabezados, tablas por moneda, indicadores de tendencia (emoji) y, si se solicita, historial de movimientos dentro del rango. Maneja respuestas amigables cuando no hay datos o ocurre un error.【F:commands/monitor.js†L330-L739】
+
+## Dependencias
+- Requiere `moment-timezone`, helpers de formato (`escapeHtml`, `fmtMoney`, `boldHeader`), `buildEntityFilter` y `sendLargeMessage`. Usa la conexión `psql/db.js` para ejecutar la consulta compleja y obtener tasas de venta.【F:commands/monitor.js†L1-L739】

--- a/docs/commands/monitor_assist.md
+++ b/docs/commands/monitor_assist.md
@@ -1,0 +1,20 @@
+# /monitor (asistente)
+
+## Descripción
+Asistente de filtros para el comando `/monitor` que permite combinar periodo, moneda, agente y banco desde un menú interactivo. Edita el mensaje en lugar de enviar nuevos, ofrece opción de ver el reporte en privado cuando se usa en grupos y reusa `runMonitor` para generar la salida final.【F:commands/monitor_assist.js†L1-L374】
+
+## Flujo principal
+1. Inicializa filtros con el periodo por defecto (`getDefaultPeriod`) y muestra un resumen editable con botones para cada filtro y para ejecutar la consulta.【F:commands/monitor_assist.js†L48-L80】【F:commands/monitor_assist.js†L212-L227】
+2. Proporciona menús específicos para periodo (día/semana/mes/año), selección de día o mes, moneda, agente y banco, incluyendo opciones “Todos” y bloqueos para fechas futuras.【F:commands/monitor_assist.js†L82-L208】
+3. Al ejecutar (`RUN`) construye un comando `/monitor` con flags según filtros activos, muestra un mensaje de “Generando reporte…”, invoca `runMonitor` y almacena los bloques devueltos para reutilizarlos o guardarlos.【F:commands/monitor_assist.js†L234-L263】
+4. Tras generar el reporte, ofrece guardar/enviar por otros canales mediante `sendReportWithKb` y `sendAndLog`, o regresar al menú para realizar otra consulta.【F:commands/monitor_assist.js†L260-L357】
+5. El botón “Ver en privado” responde con el enlace del bot cuando el comando se usa en grupos, fomentando consultas 1:1.【F:commands/monitor_assist.js†L70-L271】
+
+## Entradas relevantes
+- Callbacks inline (p.ej., `PER_*`, `DAY_*`, `MO_*`, `AG_*`, `BK_*`) y combinaciones de filtros almacenadas en `ctx.wizard.state.filters`.【F:commands/monitor_assist.js†L82-L357】
+
+## Salidas
+- Mensaje HTML resumido con filtros activos y reportes generados por `/monitor`, además de respuestas de confirmación cuando se guardan o cancelan consultas.【F:commands/monitor_assist.js†L48-L357】
+
+## Dependencias
+- Utiliza helpers de UI (`editIfChanged`, `arrangeInlineButtons`, `buildBackExitRow`, `buildSaveBackExitKeyboard`), `sendReportWithKb`, `sendAndLog`, `flushOnExit` y `runMonitor`. Consulta tablas `agente`, `banco` y `moneda` para poblar menús.【F:commands/monitor_assist.js†L21-L357】

--- a/docs/commands/resumen.md
+++ b/docs/commands/resumen.md
@@ -1,0 +1,19 @@
+# /resumen
+
+## Descripción
+Genera un resumen detallado de las transacciones de una cuenta legacy almacenada como tabla independiente. Agrupa por día, calcula subtotales diarios y totales mensuales de créditos y débitos antes de responder al usuario.【F:commands/resumen.js†L1-L82】
+
+## Flujo principal
+1. Obtiene el nombre de la cuenta desde el mensaje (`/resumen <alias>`); si falta, devuelve una advertencia inmediata.【F:commands/resumen.js†L4-L10】
+2. Ejecuta una consulta que recupera todas las filas de la tabla `<cuenta>` ordenadas por fecha e id ascendente.【F:commands/resumen.js†L12-L20】
+3. Itera sobre las filas, reseteando subtotales al cambiar de día, acumulando totales mensuales y armando una cadena con movimientos marcados como crédito (+) o débito (-).【F:commands/resumen.js†L26-L67】
+4. Devuelve el resumen completo en un único mensaje con el saldo final del mes y totales de débito/crédito acumulados.【F:commands/resumen.js†L32-L75】
+
+## Entradas relevantes
+- Nombre de la tabla/cuenta en el comando y datos almacenados en columnas `descripcion`, `debito`, `credito`, `total` y `fecha`.【F:commands/resumen.js†L4-L75】
+
+## Salidas
+- Texto plano con formato Markdown escapado que detalla movimientos por día y totales mensuales, además de manejar mensajes de error cuando la cuenta no existe o no tiene registros.【F:commands/resumen.js†L2-L79】
+
+## Dependencias
+- Utiliza `psql/db.js` para ejecutar consultas y `telegram-escape` para escapar caracteres especiales en el nombre de la cuenta.【F:commands/resumen.js†L1-L82】

--- a/docs/commands/resumentotal.md
+++ b/docs/commands/resumentotal.md
@@ -1,0 +1,19 @@
+# /resumentotal
+
+## Descripción
+Recorre todas las tablas públicas (excepto `usuarios`) y envía un resumen individual por cuenta, reutilizando la lógica de cálculo de subtotales diarios y totales mensuales de créditos/débitos de las cuentas legacy.【F:commands/resumentotal.js†L1-L115】
+
+## Flujo principal
+1. `obtenerTablas` lista las tablas visibles en `public` y filtra la tabla de control de usuarios para enfocarse en cuentas de legado.【F:commands/resumentotal.js†L4-L20】
+2. `generarResumenCuenta` ejecuta `SELECT * FROM <cuenta>` ordenado por fecha, compone el detalle diario y devuelve un bloque de texto con totales por mes.【F:commands/resumentotal.js†L22-L84】
+3. `enviarResumen` divide el texto en fragmentos de 4096 caracteres para respetar el límite de Telegram.【F:commands/resumentotal.js†L91-L99】
+4. `resumenTotal` itera sobre todas las tablas y envía cada resumen por separado, avisando si no existen cuentas registradas.【F:commands/resumentotal.js†L101-L114】
+
+## Entradas relevantes
+- Tablas existentes en el esquema público, incluyendo contenido de columnas `descripcion`, `debito`, `credito`, `total` y `fecha` por cada cuenta.【F:commands/resumentotal.js†L4-L112】
+
+## Salidas
+- Mensajes de texto con resúmenes completos por cuenta, cada uno con saldos diarios y totales mensuales de débito/crédito, o errores por cuenta vacía o inexistente.【F:commands/resumentotal.js†L32-L112】
+
+## Dependencias
+- Requiere el pool PostgreSQL y la utilidad `escapeMarkdown` para proteger el nombre de la cuenta en la salida.【F:commands/resumentotal.js†L1-L84】

--- a/docs/commands/saldo.md
+++ b/docs/commands/saldo.md
@@ -1,0 +1,20 @@
+# /saldo
+
+## Descripción
+Wizard interactivo para actualizar el saldo real de una tarjeta. Permite elegir agente, seleccionar tarjeta y registrar un movimiento con cálculo automático del delta y un historial del día, enviando además un resumen al canal de reportes.【F:commands/saldo.js†L1-L427】
+
+## Flujo principal
+1. Paso 0: muestra la lista de agentes disponibles y permite cancelar en cualquier momento mediante botones o comandos `/cancel`/`salir`.【F:commands/saldo.js†L36-L93】【F:commands/saldo.js†L171-L181】
+2. Paso 1: al seleccionar un agente carga sus tarjetas, mostrando saldo actual, banco y moneda. Si no hay tarjetas, cierra la escena.【F:commands/saldo.js†L95-L153】【F:commands/saldo.js†L183-L199】
+3. Paso 2: tras elegir tarjeta, solicita el saldo actual vía mensaje editado y permite volver a agentes o tarjetas anteriores desde el teclado inline.【F:commands/saldo.js†L156-L223】
+4. Paso 3: valida el número ingresado, calcula delta y saldo anterior consultando el último movimiento, inserta la nueva fila en `movimiento`, genera historial diario, envía mensaje de confirmación y notifica por log.【F:commands/saldo.js†L239-L350】
+5. Paso 4: ofrece continuar con otra tarjeta o agente; al salir ejecuta `runFondo` para actualizar el análisis financiero (en privado si el chat es grupo).【F:commands/saldo.js†L364-L417】
+
+## Entradas relevantes
+- Selección de agente/tarjeta mediante callbacks inline y saldo actual introducido por texto numérico.【F:commands/saldo.js†L95-L350】
+
+## Salidas
+- Mensaje HTML con resumen del ajuste, historial del día y opciones para continuar; envía también un registro al canal configurado a través de `sendAndLog`.【F:commands/saldo.js†L311-L350】
+
+## Dependencias
+- Utiliza `psql/db.js` para consultar e insertar movimientos, helpers de formato (`escapeHtml`, `fmtMoney`, `boldHeader`), `sendAndLog` para reportes, `recordChange/flushOnExit` para resúmenes de sesión y `runFondo` para disparar el asesor financiero al salir.【F:commands/saldo.js†L16-L417】

--- a/docs/commands/tarjeta.md
+++ b/docs/commands/tarjeta.md
@@ -1,0 +1,21 @@
+# /tarjeta
+
+## Descripción
+Wizard completo para crear, actualizar o eliminar tarjetas asociadas a agentes. Ofrece selección de agente, listado de tarjetas existentes, creación con banco/moneda y saldo inicial, además de un submenú de edición y borrado seguro con confirmaciones.【F:commands/tarjeta_wizard.js†L1-L547】
+
+## Flujo principal
+1. Paso 0: inicia mostrando agentes disponibles y guarda el `message_id` para reutilizarlo en ediciones; permite cancelar con botón global o comandos de salida.【F:commands/tarjeta_wizard.js†L57-L172】
+2. Paso 1: tras seleccionar agente, presenta un menú de tarjetas con acciones para editar, eliminar o añadir nuevas, usando botones inline distribuidos en filas de dos.【F:commands/tarjeta_wizard.js†L189-L286】
+3. Paso 2: al introducir un número nuevo verifica si la tarjeta existe; si sí, activa el submenú de edición (`EDIT_NUM/BANK/CURR`). Si no, solicita banco y moneda mediante listados generados dinámicamente.【F:commands/tarjeta_wizard.js†L290-L373】
+4. Paso 3: solicita saldo inicial (o botón “Iniciar en 0”), crea/actualiza la tarjeta con `INSERT ... ON CONFLICT DO UPDATE` y registra un movimiento “Saldo inicial”.【F:commands/tarjeta_wizard.js†L388-L435】
+5. Paso 4: el submenú de edición permite modificar número, banco o moneda existentes, actualizando la fila con `UPDATE` y manteniendo controles de retroceso y cancelación.【F:commands/tarjeta_wizard.js†L438-L544】
+6. El menú de eliminación pide confirmación y avisa si existen movimientos antes de borrar la tarjeta; tras eliminar regresa al menú principal.【F:commands/tarjeta_wizard.js†L243-L276】
+
+## Entradas relevantes
+- Selección mediante callbacks inline (agentes, tarjetas, bancos, monedas) y texto libre para número de tarjeta y saldo inicial.【F:commands/tarjeta_wizard.js†L57-L435】
+
+## Salidas
+- Mensajes HTML actualizados con listados, advertencias y confirmaciones de creación/actualización/eliminación, reutilizando `editIfChanged` para evitar spam.【F:commands/tarjeta_wizard.js†L57-L500】
+
+## Dependencias
+- Requiere acceso a tablas `tarjeta`, `agente`, `banco`, `moneda` y `movimiento`. Emplea helpers de UI (`arrangeInlineButtons`, `buildBackExitRow`, `editIfChanged`) y registra cambios en la sesión con `recordChange`/`flushOnExit`.【F:commands/tarjeta_wizard.js†L5-L435】

--- a/docs/commands/tarjetas.md
+++ b/docs/commands/tarjetas.md
@@ -1,0 +1,19 @@
+# /tarjetas
+
+## Descripción
+Lista todas las tarjetas registradas mostrando saldos iniciales y finales, variaciones, descripciones del último movimiento y equivalentes en USD agrupados por moneda, banco y agente.【F:commands/tarjetas.js†L1-L209】
+
+## Flujo principal
+1. Ejecuta `LAST_MOVEMENTS_SQL` para obtener, por tarjeta, el último movimiento junto con metadatos de agente, banco, moneda, emojis y tasa USD.【F:commands/tarjetas.js†L25-L58】
+2. Agrupa las filas por moneda, sumando saldos iniciales y finales, y anida agregaciones por banco y por agente para construir resúmenes temáticos.【F:commands/tarjetas.js†L60-L133】
+3. Construye bloques de salida con totales por moneda, por agente (en USD), detalle por tarjeta y subtotales por banco, incluyendo marcas temporales y descripciones cuando existen.【F:commands/tarjetas.js†L135-L199】
+4. Envía todos los bloques en secuencia usando `sendLargeMessage` para respetar el límite de caracteres de Telegram.【F:commands/tarjetas.js†L135-L205】
+
+## Entradas relevantes
+- No recibe argumentos adicionales; usa la conexión PostgreSQL (`pool`) y la consulta SQL embebida.【F:commands/tarjetas.js†L7-L58】
+
+## Salidas
+- Bloques HTML con encabezados en negritas, listas de tarjetas, subtotales y equivalentes en USD, generados mediante utilidades de formato (`escapeHtml`, `boldHeader`, `fmt`).【F:commands/tarjetas.js†L14-L205】
+
+## Dependencias
+- Utiliza `helpers/format` para escapar HTML y destacar encabezados, y `helpers/sendLargeMessage` para dividir mensajes extensos.【F:commands/tarjetas.js†L7-L205】

--- a/docs/commands/tarjetas_assist.md
+++ b/docs/commands/tarjetas_assist.md
@@ -1,0 +1,19 @@
+# /tarjetas (asistente)
+
+## Descripción
+Asistente de navegación que permite explorar tarjetas sin generar nuevos mensajes: ofrece vistas por agente, por combinación moneda-banco, resumen global y detalle completo, reutilizando `sendLargeMessage` para bloques extensos y teclados inline para moverse entre rutas.【F:commands/tarjetas_assist.js†L1-L220】
+
+## Flujo principal
+1. Carga todos los saldos de tarjetas con metadatos de agente, banco y moneda, agrupando por agente y por moneda/banco para construir estructuras reutilizables.【F:commands/tarjetas_assist.js†L82-L168】
+2. Presenta un menú principal con opciones “Por moneda y banco”, “Por agente”, “Resumen USD global” y “Ver todas”, cada una navegable con botones `Volver`/`Salir`.【F:commands/tarjetas_assist.js†L170-L204】
+3. Las rutas de agente muestran tarjetas y totales por moneda, mientras que las vistas por moneda+banco separan saldos positivos y negativos para resaltar capacidad versus deudas.【F:commands/tarjetas_assist.js†L206-L220】
+4. Todas las respuestas se envían editando el mensaje original mediante `editIfChanged`; para listados largos se usa `sendLargeMessage` o `sendReportWithKb` evitando errores 400 por contenido repetido.【F:commands/tarjetas_assist.js†L25-L204】
+
+## Entradas relevantes
+- Interacción del operador mediante callbacks inline (`AG_*`, `MON_*`, etc.) y botones de navegación estándar (`Volver`, `Salir`).【F:commands/tarjetas_assist.js†L170-L220】
+
+## Salidas
+- Bloques HTML escapados con resúmenes por agente y moneda, enviados como mensaje editado o división automática cuando superan los 4096 caracteres.【F:commands/tarjetas_assist.js†L25-L220】
+
+## Dependencias
+- Utiliza helpers de UI (`editIfChanged`, `arrangeInlineButtons`, `buildBackExitRow`) y `sendLargeMessage`/`sendAndLog` para reportes, además del pool PostgreSQL para obtener datos.【F:commands/tarjetas_assist.js†L24-L220】

--- a/docs/commands/usuariosconacceso.md
+++ b/docs/commands/usuariosconacceso.md
@@ -1,0 +1,13 @@
+# Helper: usuarios con acceso
+
+## Descripción
+Módulo auxiliar que expone funciones CRUD simples sobre la tabla `usuarios`, utilizada por `/acceso` para gestionar la lista blanca del bot.【F:commands/usuariosconacceso.js†L1-L59】
+
+## Funciones
+- `agregarUsuario(user_id)`: inserta el identificador y fecha actual en la tabla, registrando la operación en consola.【F:commands/usuariosconacceso.js†L9-L21】
+- `eliminarUsuario(user_id)`: borra la fila correspondiente y deja trazas de error si falla.【F:commands/usuariosconacceso.js†L24-L36】
+- `usuarioExiste(user_id)`: comprueba la existencia del usuario devolviendo `true/false` según el conteo.【F:commands/usuariosconacceso.js†L39-L52】
+- `listarUsuarios()`: devuelve un arreglo de ids ordenado por fecha; en caso de error retorna arreglo vacío.【F:commands/usuariosconacceso.js†L55-L59】
+
+## Dependencias
+- Utiliza el pool PostgreSQL definido en `psql/db.js`; las consultas se ejecutan con SQL sencillo e incluyen manejo básico de errores con `console.error`.【F:commands/usuariosconacceso.js†L1-L59】


### PR DESCRIPTION
## Summary
- add a fondo vs tarjetas audit document that explains the aggregation differences
- document every command module in docs/commands with purpose, flow, inputs, outputs, and dependencies

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9e2cee798832d81730a32f70e3b1c