### PR TITLE
Add assistant hub wizard for navigation

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,6 +44,8 @@ const tarjetasAssist  = require('./commands/tarjetas_assist');
 const monitorAssist   = require('./commands/monitor_assist');
 const accesoAssist    = require('./commands/acceso_assist');
 const extractoAssist  = require('./commands/extracto_assist');
+const assistMenu      = require('./commands/assist_menu');
+const { enterAssistMenu } = require('./helpers/assistMenu');
 const { registerFondoAdvisor, runFondo } = require('./middlewares/fondoAdvisor');
 
 /* ───────── 6. Inicializar BD (idempotente) ───────── */
@@ -59,12 +61,24 @@ async function initDatabase() {
 
 /* ───────── 7. Scenes / Stage ───────── */
 const stage = new Scenes.Stage(
-  [tarjetaWizard, saldoWizard, tarjetasAssist, monitorAssist, accesoAssist, extractoAssist]
+  [
+    tarjetaWizard,
+    saldoWizard,
+    tarjetasAssist,
+    monitorAssist,
+    accesoAssist,
+    extractoAssist,
+    assistMenu,
+  ]
 );
 stage.hears(/^(salir)$/i, async (ctx) => {
+  const currentId = ctx.scene?.current?.id;
   await flushOnExit(ctx);
   if (ctx.scene?.current) await ctx.scene.leave();
   await ctx.reply('❌ Operación cancelada.');
+  if (currentId !== 'ASSISTANT_MENU') {
+    await enterAssistMenu(ctx);
+  }
 });
 bot.use(session());
 bot.use(stage.middleware());
@@ -149,6 +163,7 @@ bot.command('tarjetas', (ctx) => ctx.scene.enter('TARJETAS_ASSIST'));
 bot.command('monitor',  (ctx) => ctx.scene.enter('MONITOR_ASSIST'));
 bot.command('acceso',   ownerOnly((ctx) => ctx.scene.enter('ACCESO_ASSIST')));
 bot.command('extracto', (ctx) => ctx.scene.enter('EXTRACTO_ASSIST'));
+bot.command('menu',     (ctx) => ctx.scene.enter('ASSISTANT_MENU'));
 bot.command('fondo',    safe(require('./commands/fondo')));
 
 /* ───────── 13. Gestión de accesos (solo OWNER) ───────── */

--- a/commands/assist_menu.js
+++ b/commands/assist_menu.js
@@ -1,0 +1,44 @@
+const { Scenes } = require('telegraf');
+const { createExitHandler } = require('../helpers/wizard');
+const { buildMenuKeyboard, getMenuItems } = require('../helpers/assistMenu');
+
+const wantExit = createExitHandler({
+  logPrefix: 'assist_menu',
+  notify: false,
+  beforeLeave: async (ctx) => {
+    const messageId = ctx.wizard?.state?.msgId;
+    if (!messageId || !ctx.chat) return;
+    await ctx.telegram.deleteMessage(ctx.chat.id, messageId).catch(() => {});
+  },
+});
+
+const assistMenu = new Scenes.WizardScene(
+  'ASSISTANT_MENU',
+  async (ctx) => {
+    const msg = await ctx.reply('Selecciona un asistente para continuar:', {
+      parse_mode: 'HTML',
+      reply_markup: buildMenuKeyboard(ctx).reply_markup,
+    });
+    ctx.wizard.state.msgId = msg.message_id;
+    ctx.wizard.state.route = 'MENU';
+    return ctx.wizard.next();
+  },
+  async (ctx) => {
+    if (await wantExit(ctx)) return;
+    const data = ctx.callbackQuery?.data;
+    if (!data) return;
+    await ctx.answerCbQuery().catch(() => {});
+    if (!data.startsWith('ASSIST:')) return;
+    const scene = data.split(':')[1];
+    const items = getMenuItems(ctx);
+    const target = items.find((item) => item.scene === scene);
+    if (!target) return;
+    const messageId = ctx.wizard?.state?.msgId;
+    if (messageId) {
+      await ctx.telegram.deleteMessage(ctx.chat.id, messageId).catch(() => {});
+    }
+    await ctx.scene.enter(target.scene);
+  }
+);
+
+module.exports = assistMenu;

--- a/commands/extracto_assist.js
+++ b/commands/extracto_assist.js
@@ -24,11 +24,15 @@ const {
   sendReportWithKb,
 } = require('../helpers/ui');
 const { createExitHandler } = require('../helpers/wizard');
+const { enterAssistMenu } = require('../helpers/assistMenu');
 const pool = require('../psql/db.js');
 
 /* Helpers ----------------------------------------------------------------- */
 
-const wantExit = createExitHandler({ logPrefix: 'extracto' });
+const wantExit = createExitHandler({
+  logPrefix: 'extracto',
+  afterLeave: enterAssistMenu,
+});
 
 /* ───────── DB helpers — todos con try/catch para depurar ───────── */
 

--- a/commands/monitor_assist.js
+++ b/commands/monitor_assist.js
@@ -33,8 +33,12 @@ const {
 const pool = require('../psql/db.js');
 const { runMonitor } = require('./monitor');
 const { createExitHandler } = require('../helpers/wizard');
+const { enterAssistMenu } = require('../helpers/assistMenu');
 
-const wantExit = createExitHandler({ logPrefix: 'MONITOR_ASSIST' });
+const wantExit = createExitHandler({
+  logPrefix: 'MONITOR_ASSIST',
+  afterLeave: enterAssistMenu,
+});
 
 async function showMain(ctx) {
   const f = ctx.wizard.state.filters;

--- a/commands/saldo.js
+++ b/commands/saldo.js
@@ -21,6 +21,7 @@ const { runFondo } = require('../middlewares/fondoAdvisor');
 const pool = require('../psql/db.js');
 const moment = require('moment-timezone');
 const { createExitHandler } = require('../helpers/wizard');
+const { enterAssistMenu } = require('../helpers/assistMenu');
 
 /* ───────── helpers ───────── */
 const kbBackOrCancel = Markup.inlineKeyboard([
@@ -37,6 +38,7 @@ const kbContinue = Markup.inlineKeyboard([
 const wantExit = createExitHandler({
   callbackValues: ['GLOBAL_CANCEL'],
   logPrefix: 'saldo',
+  afterLeave: enterAssistMenu,
 });
 
 async function showAgentes(ctx) {

--- a/commands/tarjetas_assist.js
+++ b/commands/tarjetas_assist.js
@@ -34,6 +34,7 @@ const {
   sendReportWithKb,
 } = require('../helpers/ui');
 const { createExitHandler } = require('../helpers/wizard');
+const { enterAssistMenu } = require('../helpers/assistMenu');
 const pool = require('../psql/db.js');
 
 /* ───────── helpers ───────── */
@@ -71,6 +72,7 @@ const wantExit = createExitHandler({
       })
       .catch(() => {});
   },
+  afterLeave: enterAssistMenu,
 });
 
 async function loadData() {

--- a/helpers/assistMenu.js
+++ b/helpers/assistMenu.js
@@ -1,0 +1,60 @@
+const { Markup } = require('telegraf');
+const { arrangeInlineButtons } = require('./ui');
+const { ownerIds } = require('../config');
+
+const MENU_ITEMS = [
+  { scene: 'MONITOR_ASSIST', label: '📈 Monitor', ownerOnly: false },
+  { scene: 'SALDO_WIZ', label: '💰 Saldo', ownerOnly: false },
+  { scene: 'TARJETAS_ASSIST', label: '💳 Tarjetas', ownerOnly: false },
+  { scene: 'EXTRACTO_ASSIST', label: '📄 Extracto', ownerOnly: false },
+  { scene: 'ACCESO_ASSIST', label: '🔐 Accesos', ownerOnly: true },
+  { scene: 'TARJETA_WIZ', label: '➕ Tarjeta', ownerOnly: true },
+  { scene: 'AGENTE_WIZ', label: '🧑‍💼 Agentes', ownerOnly: true },
+  { scene: 'BANCO_CREATE_WIZ', label: '🏦 Bancos', ownerOnly: true },
+  { scene: 'MONEDA_WIZ', label: '💱 Monedas', ownerOnly: true },
+];
+
+function isOwner(ctx) {
+  const uid = Number(ctx.from?.id || 0);
+  return ownerIds.includes(uid);
+}
+
+function getMenuItems(ctx, extraItems = []) {
+  const allowOwner = isOwner(ctx);
+  return [...MENU_ITEMS, ...extraItems].filter((item) =>
+    allowOwner ? true : !item.ownerOnly
+  );
+}
+
+function buildMenuKeyboard(ctx, { includeExit = true, extraItems = [] } = {}) {
+  const items = getMenuItems(ctx, extraItems);
+  const buttons = items.map((item) =>
+    Markup.button.callback(item.label, `ASSIST:${item.scene}`)
+  );
+  const rows = arrangeInlineButtons(buttons);
+  if (includeExit) {
+    rows.push([Markup.button.callback('❌ Cerrar', 'EXIT')]);
+  }
+  return Markup.inlineKeyboard(rows);
+}
+
+async function sendAssistMenu(ctx, { text = 'Elige un asistente para continuar:', includeExit = true, extraItems = [] } = {}) {
+  const keyboard = buildMenuKeyboard(ctx, { includeExit, extraItems });
+  return ctx.reply(text, { parse_mode: 'HTML', reply_markup: keyboard.reply_markup });
+}
+
+async function enterAssistMenu(ctx, opts = {}) {
+  if (!ctx?.scene) return;
+  try {
+    await ctx.scene.enter('ASSISTANT_MENU', opts);
+  } catch (err) {
+    console.error('[assistMenu] No se pudo entrar al menú de asistentes:', err);
+  }
+}
+
+module.exports = {
+  buildMenuKeyboard,
+  sendAssistMenu,
+  enterAssistMenu,
+  getMenuItems,
+};


### PR DESCRIPTION
## Summary
- add a central ASSISTANT_MENU wizard and helper to list available assistants
- register the hub in the stage, expose `/menu`, and reopen it after leaving other wizards
- ensure monitor, saldo, tarjetas, and extracto wizards fall back to the assistant hub on exit

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68daf0dab5cc832da7394958ab5e40c6