### PR TITLE
Refactor monitor wizard navigation and restore agent scene

### DIFF
--- a/commands/agente.js
+++ b/commands/agente.js
@@ -1,6 +1,10 @@
 // commands/agente.js
 const { Scenes, Markup } = require('telegraf');
 const pool = require('../psql/db.js'); // tu Pool de PostgreSQL
+const { escapeHtml } = require('../helpers/format');
+const { renderWizardMenu, clearWizardMenu } = require('../helpers/ui');
+const { createExitHandler } = require('../helpers/wizard');
+const { enterAssistMenu } = require('../helpers/assistMenu');
 
 /* Tecla de cancelar / salir para wizards */
 const cancelKb = Markup.inlineKeyboard([[Markup.button.callback('↩️ Cancelar', 'GLOBAL_CANCEL')]]);
@@ -31,6 +35,172 @@ async function checkExit(ctx) {
   }
   return false;
 }
+
+async function fetchAgentsList() {
+  const res = await pool.query('SELECT id,nombre,emoji FROM agente ORDER BY nombre');
+  return res.rows;
+}
+
+function buildAgentsText(rows = []) {
+  if (!rows.length) {
+    return 'No hay agentes registrados aún.';
+  }
+  return rows
+    .map((a) => `• ${a.emoji ? `${escapeHtml(a.emoji)} ` : ''}${escapeHtml(a.nombre)}`)
+    .join('\n');
+}
+
+function buildAgentsKeyboard(rows = [], { includeExit = false, includeRefresh = false } = {}) {
+  const kb = rows.map((a) => [
+    Markup.button.callback(`✏️ ${a.nombre}`, `AGENTE_EDIT_${a.id}`),
+    Markup.button.callback('🗑️', `AGENTE_DEL_${a.id}`),
+  ]);
+  kb.push([Markup.button.callback('➕ Añadir', 'AGENTE_ADD')]);
+  if (includeRefresh) {
+    kb.push([Markup.button.callback('🔄 Actualizar', 'AGENTE_REFRESH')]);
+  }
+  if (includeExit) {
+    kb.push([Markup.button.callback('❌ Salir', 'EXIT')]);
+  }
+  return kb;
+}
+
+async function renderAgentWizardMenu(ctx, { pushHistory = true } = {}) {
+  const rows = await fetchAgentsList();
+  const text =
+    '🧑‍💼 <b>Gestor de agentes</b>\n\n' +
+    buildAgentsText(rows) +
+    '\n\nPulsa un agente para editar o eliminar.';
+  await renderWizardMenu(ctx, {
+    route: 'LIST',
+    text,
+    extra: { reply_markup: { inline_keyboard: buildAgentsKeyboard(rows, { includeExit: true, includeRefresh: true }) } },
+    pushHistory,
+  });
+}
+
+async function handleAgentEdit(ctx, id) {
+  try {
+    const res = await pool.query('SELECT * FROM agente WHERE id=$1', [id]);
+    if (!res.rows.length) {
+      await ctx.reply('No se encontró ese agente.');
+      return;
+    }
+    await clearWizardMenu(ctx);
+    return ctx.scene.enter('AGENTE_EDIT_WIZ', { edit: res.rows[0] });
+  } catch (e) {
+    console.error('[agente] Error obteniendo agente para edición:', e);
+    await ctx.reply('❌ Error al obtener el agente.');
+  }
+}
+
+async function handleAgentDeletePrompt(ctx, id) {
+  let msg = `¿Eliminar el agente con ID ${id}?`;
+  try {
+    const dep = await pool.query(
+      `SELECT
+         (SELECT COUNT(*) FROM tarjeta WHERE agente_id=$1) AS tarjetas,
+         (SELECT COUNT(*) FROM movimiento m
+            JOIN tarjeta t ON m.tarjeta_id=t.id
+          WHERE t.agente_id=$1) AS movimientos`,
+      [id],
+    );
+    const { tarjetas, movimientos } = dep.rows[0];
+    if (tarjetas > 0 || movimientos > 0) {
+      msg =
+        `⚠️ Este agente tiene ${tarjetas} tarjeta(s) y ${movimientos} movimiento(s) asociados. ` +
+        'Si lo eliminas, se borrarán esas informaciones. ¿Continuar?';
+    }
+  } catch (e) {
+    console.error('[agente] Error verificando dependencias:', e);
+  }
+  await ctx.reply(
+    msg,
+    Markup.inlineKeyboard([
+      Markup.button.callback('Sí, eliminar', `AGENTE_DEL_CONF_${id}`),
+      Markup.button.callback('Cancelar', 'AGENTE_CANCEL'),
+    ]),
+  );
+}
+
+async function handleAgentDeleteConfirm(ctx, id) {
+  try {
+    await pool.query('BEGIN');
+    await pool.query('DELETE FROM tarjeta WHERE agente_id=$1', [id]);
+    await pool.query('DELETE FROM agente WHERE id=$1', [id]);
+    await pool.query('COMMIT');
+    await ctx.reply('✅ Agente eliminado.');
+  } catch (e) {
+    await pool.query('ROLLBACK');
+    console.error('[agente] Error eliminando agente:', e);
+    await ctx.reply('❌ No se pudo eliminar el agente.');
+    return;
+  }
+  if (ctx.scene?.current?.id === 'AGENTE_WIZ') {
+    await renderAgentWizardMenu(ctx, { pushHistory: false });
+  }
+}
+
+async function handleAgentCancel(ctx) {
+  if (ctx.scene?.current?.id === 'AGENTE_WIZ') {
+    await clearWizardMenu(ctx);
+    ctx.wizard.state.nav = { stack: [] };
+    await ctx.reply('Operación cancelada.');
+    await renderAgentWizardMenu(ctx, { pushHistory: false });
+    return;
+  }
+  if (ctx.scene?.current) await ctx.scene.leave();
+  await ctx.reply('Operación cancelada.');
+}
+
+const exitAgentWizard = createExitHandler({
+  logPrefix: 'AGENTE_WIZ',
+  beforeLeave: clearWizardMenu,
+  afterLeave: enterAssistMenu,
+  notify: false,
+});
+
+const agenteWizard = new Scenes.WizardScene(
+  'AGENTE_WIZ',
+  async (ctx) => {
+    ctx.wizard.state.nav = { stack: [] };
+    await renderAgentWizardMenu(ctx, { pushHistory: false });
+    return ctx.wizard.next();
+  },
+  async (ctx) => {
+    if (await exitAgentWizard(ctx)) return;
+    const data = ctx.callbackQuery?.data;
+    if (!data) return;
+    if (data === 'AGENTE_REFRESH') {
+      await ctx.answerCbQuery().catch(() => {});
+      return renderAgentWizardMenu(ctx, { pushHistory: false });
+    }
+    if (data === 'AGENTE_ADD') {
+      await ctx.answerCbQuery().catch(() => {});
+      await clearWizardMenu(ctx);
+      return ctx.scene.enter('AGENTE_CREATE_WIZ');
+    }
+    const editMatch = data.match(/^AGENTE_EDIT_(\d+)$/);
+    if (editMatch) {
+      await ctx.answerCbQuery().catch(() => {});
+      return handleAgentEdit(ctx, Number(editMatch[1]));
+    }
+    const delMatch = data.match(/^AGENTE_DEL_(\d+)$/);
+    if (delMatch) {
+      await ctx.answerCbQuery().catch(() => {});
+      return handleAgentDeletePrompt(ctx, Number(delMatch[1]));
+    }
+    const delConfMatch = data.match(/^AGENTE_DEL_CONF_(\d+)$/);
+    if (delConfMatch) {
+      await ctx.answerCbQuery().catch(() => {});
+      return handleAgentDeleteConfirm(ctx, Number(delConfMatch[1]));
+    }
+    if (data === 'AGENTE_CANCEL') {
+      await ctx.answerCbQuery().catch(() => {});
+      return handleAgentCancel(ctx);
+    }
+  },
+);
 
 // ---------------------- WIZARD: crear agente ----------------------
 const crearAgenteWizard = new Scenes.WizardScene(
@@ -113,20 +283,20 @@ const editarAgenteWizard = new Scenes.WizardScene(
 
 // ---------------------- Registro y manejo de comandos ----------------------
 const registerAgente = (bot, stage) => {
+  stage.register(agenteWizard);
   stage.register(crearAgenteWizard);
   stage.register(editarAgenteWizard);
 
   bot.command('agentes', async (ctx) => {
     console.log('[agentes] listado solicitado');
     try {
-      const rows = (await pool.query('SELECT id, nombre FROM agente ORDER BY nombre')).rows;
-      const txt = rows.length ? rows.map(a => `• ${a.nombre}`).join('\n') : 'No hay agentes registrados aún.';
-      const kb = rows.map(a => [
-        Markup.button.callback(`✏️ ${a.nombre}`, `AGENTE_EDIT_${a.id}`),
-        Markup.button.callback('🗑️', `AGENTE_DEL_${a.id}`)
-      ]);
-      kb.push([Markup.button.callback('➕ Añadir', 'AGENTE_ADD')]);
-      await ctx.reply(txt, Markup.inlineKeyboard(kb));
+      const rows = await fetchAgentsList();
+      const text = '🧑‍💼 <b>Agentes</b>\n\n' + buildAgentsText(rows);
+      const kb = buildAgentsKeyboard(rows);
+      await ctx.reply(text, {
+        parse_mode: 'HTML',
+        reply_markup: { inline_keyboard: kb },
+      });
     } catch (e) {
       console.error('[agentes] Error listando agentes:', e);
       await ctx.reply('❌ Ocurrió un error al listar los agentes.');
@@ -137,6 +307,7 @@ const registerAgente = (bot, stage) => {
   bot.action('AGENTE_ADD', async (ctx) => {
     console.log('[action] AGENTE_ADD');
     await ctx.answerCbQuery().catch(() => {});
+    await clearWizardMenu(ctx);
     return ctx.scene.enter('AGENTE_CREATE_WIZ');
   });
 
@@ -144,72 +315,27 @@ const registerAgente = (bot, stage) => {
     console.log('[action] AGENTE_EDIT', ctx.match);
     await ctx.answerCbQuery().catch(() => {});
     const id = +ctx.match[1];
-    try {
-      const res = await pool.query('SELECT * FROM agente WHERE id=$1', [id]);
-      if (!res.rows.length) {
-        await ctx.reply('No se encontró ese agente.');
-        return;
-      }
-      return ctx.scene.enter('AGENTE_EDIT_WIZ', { edit: res.rows[0] });
-    } catch (e) {
-      console.error('[action] AGENTE_EDIT error fetching:', e);
-      await ctx.reply('❌ Error al obtener el agente.');
-    }
+    return handleAgentEdit(ctx, id);
   });
 
   bot.action(/^AGENTE_DEL_(\d+)$/, async (ctx) => {
     console.log('[action] AGENTE_DEL', ctx.match);
     await ctx.answerCbQuery().catch(() => {});
     const id = +ctx.match[1];
-    let msg = `¿Eliminar el agente con ID ${id}?`;
-    try {
-      const dep = await pool.query(
-        `SELECT
-           (SELECT COUNT(*) FROM tarjeta WHERE agente_id=$1) AS tarjetas,
-           (SELECT COUNT(*) FROM movimiento m
-              JOIN tarjeta t ON m.tarjeta_id=t.id
-            WHERE t.agente_id=$1) AS movimientos`,
-        [id]
-      );
-      const { tarjetas, movimientos } = dep.rows[0];
-      if (tarjetas > 0 || movimientos > 0) {
-        msg = `⚠️ Este agente tiene ${tarjetas} tarjeta(s) y ${movimientos} movimiento(s) asociados. ` +
-              'Si lo eliminas, se borrarán esas informaciones. ¿Continuar?';
-      }
-    } catch (e) {
-      console.error('[action] AGENTE_DEL dependency check error:', e);
-    }
-    await ctx.reply(
-      msg,
-      Markup.inlineKeyboard([
-        Markup.button.callback('Sí, eliminar', `AGENTE_DEL_CONF_${id}`),
-        Markup.button.callback('Cancelar', 'AGENTE_CANCEL')
-      ])
-    );
+    return handleAgentDeletePrompt(ctx, id);
   });
 
   bot.action(/^AGENTE_DEL_CONF_(\d+)$/, async (ctx) => {
     console.log('[action] AGENTE_DEL_CONF', ctx.match);
     await ctx.answerCbQuery().catch(() => {});
     const id = +ctx.match[1];
-    try {
-      await pool.query('BEGIN');
-      await pool.query('DELETE FROM tarjeta WHERE agente_id=$1', [id]);
-      await pool.query('DELETE FROM agente WHERE id=$1', [id]);
-      await pool.query('COMMIT');
-      await ctx.reply('✅ Agente eliminado.');
-    } catch (e) {
-      await pool.query('ROLLBACK');
-      console.error('[action] AGENTE_DEL_CONF error:', e);
-      await ctx.reply('❌ No se pudo eliminar el agente.');
-    }
+    return handleAgentDeleteConfirm(ctx, id);
   });
 
   bot.action('AGENTE_CANCEL', async (ctx) => {
     console.log('[action] AGENTE_CANCEL');
     await ctx.answerCbQuery().catch(() => {});
-    if (ctx.scene?.current) await ctx.scene.leave();
-    await ctx.reply('Operación cancelada.');
+    await handleAgentCancel(ctx);
   });
 
   // soporte global para salir de cualquier wizard de agente escribiendo salir o /cancel

--- a/tests/commands/assistantsUX.test.js
+++ b/tests/commands/assistantsUX.test.js
@@ -36,14 +36,16 @@ test('monitorAssist envía teclado y no edita después', async () => {
       state: {
         route: 'MAIN',
         filters: { period: 'dia', monedaNombre: 'Todas' },
-        msgId: 1,
-        lastRender: {}
+        nav: { stack: [], msgId: 1, current: 'MAIN' },
       }
     },
     callbackQuery: { data: 'RUN', message: { message_id: 1 } },
     answerCbQuery: jest.fn().mockResolvedValue(),
-    reply: jest.fn().mockResolvedValue(true),
-    telegram: { editMessageText: jest.fn().mockResolvedValue(true) },
+    reply: jest.fn().mockResolvedValue({ message_id: 2 }),
+    telegram: {
+      editMessageText: jest.fn(),
+      deleteMessage: jest.fn().mockResolvedValue(true),
+    },
     botInfo: {}
   };
   await monitorAssist.steps[1](ctx);
@@ -55,7 +57,6 @@ test('monitorAssist envía teclado y no edita después', async () => {
   expect(kb[0][1].text).toMatch('Volver');
   expect(kb[1]).toHaveLength(1);
   expect(kb[1][0].text).toMatch('Salir');
-  const editOrder = ctx.telegram.editMessageText.mock.invocationCallOrder[0];
-  const replyOrder = ctx.reply.mock.invocationCallOrder.slice(-1)[0];
-  expect(replyOrder).toBeGreaterThan(editOrder);
+  expect(ctx.telegram.editMessageText).not.toHaveBeenCalled();
+  expect(ctx.telegram.deleteMessage).toHaveBeenCalled();
 });

--- a/tests/commands/menus.test.js
+++ b/tests/commands/menus.test.js
@@ -5,8 +5,9 @@ const moment = require('moment');
 function createCtx() {
   return {
     chat: { id: 1 },
-    wizard: { state: { msgId: 1 } },
-    telegram: { editMessageText: jest.fn().mockResolvedValue(true) },
+    wizard: { state: {} },
+    telegram: { deleteMessage: jest.fn().mockResolvedValue(true) },
+    reply: jest.fn().mockResolvedValue({ message_id: 42 }),
     answerCbQuery: jest.fn().mockResolvedValue(),
   };
 }
@@ -15,7 +16,7 @@ describe('showDayMenu', () => {
   test('bloquea días futuros', async () => {
     const ctx = createCtx();
     await showDayMenu(ctx);
-    const extra = ctx.telegram.editMessageText.mock.calls[0][4];
+    const extra = ctx.reply.mock.calls[0][1];
     const markup = extra.reply_markup.inline_keyboard;
     const today = moment().date();
     const daysInMonth = moment().daysInMonth();
@@ -30,7 +31,7 @@ describe('showMonthMenu', () => {
   test('bloquea meses futuros', async () => {
     const ctx = createCtx();
     await showMonthMenu(ctx);
-    const extra = ctx.telegram.editMessageText.mock.calls[0][4];
+    const extra = ctx.reply.mock.calls[0][1];
     const markup = extra.reply_markup.inline_keyboard;
     const current = moment().month();
     if (current < 11) {


### PR DESCRIPTION
## Summary
- add reusable navigation helpers that rebuild menus instead of editing messages
- refactor MONITOR_ASSIST to use the new helpers, manage history, and clean generated reports
- reintroduce an AGENTE_WIZ scene with refreshed menus and update related tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68daf66a396c832d8ab4c2470f7d8933