### PR TITLE
Handle missing wizard context when leaving saldo wizard

### DIFF
--- a/commands/saldo.js
+++ b/commands/saldo.js
@@ -370,7 +370,9 @@ const saldoWizard = new Scenes.WizardScene(
 );
 
 async function handleSaldoLeave(ctx) {
-  ctx.wizard.state = {};
+  if (ctx.wizard) {
+    ctx.wizard.state = {};
+  }
 
   try {
     const chatType = ctx.chat?.type;


### PR DESCRIPTION
## Summary
- prevent the saldo wizard leave handler from touching an absent wizard context so cancel/exit actions succeed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db1a56e614832d90c8b8ea8f6b263f