### PR TITLE
Ajusta cancelación en wizard de saldo

### DIFF
--- a/commands/saldo.js
+++ b/commands/saldo.js
@@ -153,7 +153,10 @@ const saldoWizard = new Scenes.WizardScene(
   /* 0 – mostrar agentes */
   async ctx => {
     console.log('[SALDO_WIZ] paso 0: mostrar agentes');
-    registerCancelHooks(ctx, { afterLeave: enterAssistMenu });
+    registerCancelHooks(ctx, {
+      afterLeave: enterAssistMenu,
+      notify: false, // evitamos mensaje genérico: mostramos fondo y luego menú
+    });
     const ok = await showAgentes(ctx);
     if (!ok) return ctx.scene.leave();
     return ctx.wizard.next();


### PR DESCRIPTION
## Summary
- evita el mensaje genérico de cancelación en el wizard de saldo para mostrar el fondo y reabrir el menú de asistentes
- actualiza las pruebas de cancelación del wizard para verificar el envío del fondo y la ausencia del mensaje de cancelación

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db3855ead8832db4108132beba5c1e