### PR TITLE
Fix monedas menu to use existing wizard scene

### DIFF
--- a/app.js
+++ b/app.js
@@ -151,7 +151,7 @@ bot.command('resumen',        safe(resumirCuenta));
 bot.command('resumentotal',   safe(resumenTotal));
 
 /* ───────── 12. Nuevos comandos (wizards) ───────── */
-bot.command('monedas',  ownerOnly((ctx) => ctx.scene.enter('MONEDA_WIZ')));
+bot.command('monedas',  ownerOnly((ctx) => ctx.scene.enter('MONEDA_CREATE_WIZ')));
 bot.command('bancos',   ownerOnly((ctx) => ctx.scene.enter('BANCO_CREATE_WIZ')));
 bot.command('agentes',  ownerOnly((ctx) => ctx.scene.enter('AGENTE_WIZ')));
 bot.command('tarjeta',  ownerOnly((ctx) => ctx.scene.enter('TARJETA_WIZ')));

--- a/helpers/assistMenu.js
+++ b/helpers/assistMenu.js
@@ -11,7 +11,7 @@ const MENU_ITEMS = [
   { scene: 'TARJETA_WIZ', label: '➕ Tarjeta', ownerOnly: true },
   { scene: 'AGENTE_WIZ', label: '🧑‍💼 Agentes', ownerOnly: true },
   { scene: 'BANCO_CREATE_WIZ', label: '🏦 Bancos', ownerOnly: true },
-  { scene: 'MONEDA_WIZ', label: '💱 Monedas', ownerOnly: true },
+  { scene: 'MONEDA_CREATE_WIZ', label: '💱 Monedas', ownerOnly: true },
 ];
 
 function isOwner(ctx) {


### PR DESCRIPTION
## Summary
- align the Monedas assist menu entry with the existing `MONEDA_CREATE_WIZ` scene
- update the `/monedas` command to launch the same wizard to avoid missing-scene errors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc35528dfc832dac38caf46021df8e