### PR TITLE
Improve fondoAdvisor buy/sell guidance formatting

### DIFF
--- a/middlewares/fondoAdvisor.js
+++ b/middlewares/fondoAdvisor.js
@@ -848,22 +848,41 @@ function renderAdvice(result) {
     console.error('[fondoAdvisor] Inventario USD render error:', e.message);
   }
 
-  const venta = [
-    '💸 <b>Venta requerida (Zelle)</b>',
-    `• Objetivo: vender ${fmtUsd(plan.sellTarget.usd)} USD a ${fmtCup(plan.sellNet)} ⇒ +${fmtCup(plan.sellTarget.cupIn)} CUP`,
-  ];
-  const sellNowLine = `• Vende ahora: ${fmtUsd(plan.sellNow.usd)} USD ⇒ +${fmtCup(plan.sellNow.cupIn)} CUP`;
-  if (plan.sellNow.usd === 0 && plan.sellNow.minWarning) {
+  const sellTargetUsd = plan?.sellTarget?.usd || 0;
+  const sellTargetCupIn = plan?.sellTarget?.cupIn || 0;
+  const sellNowUsd = plan?.sellNow?.usd || 0;
+  const sellNowCupInPlan = plan?.sellNow?.cupIn || 0;
+  const sellRemainingCup = plan?.remainingCup || 0;
+  const sellRemainingUsd = plan?.remainingUsd || 0;
+  const showSellBlock = [
+    sellTargetUsd,
+    sellTargetCupIn,
+    sellNowUsd,
+    sellNowCupInPlan,
+    sellRemainingCup,
+    sellRemainingUsd,
+  ].some((value) => Math.abs(value) > 0);
+
+  if (showSellBlock) {
+    const venta = [
+      '',
+      '💸 <b>Venta requerida (Zelle)</b>',
+      `👉 Objetivo: vender ${fmtUsd(plan.sellTarget.usd)} USD a ${fmtCup(plan.sellNet)} ⇒ +${fmtCup(plan.sellTarget.cupIn)} CUP`,
+    ];
+    const sellNowLine = `👉 Vende ahora: ${fmtUsd(plan.sellNow.usd)} USD ⇒ +${fmtCup(plan.sellNow.cupIn)} CUP`;
+    if (plan.sellNow.usd === 0 && plan.sellNow.minWarning) {
+      venta.push(
+        `${sellNowLine} (⚠️ inventario menor al mínimo de ${fmtUsd(config.minSellUsd)} USD)`
+      );
+    } else {
+      venta.push(sellNowLine);
+    }
     venta.push(
-      `${sellNowLine} (⚠️ inventario menor al mínimo de ${fmtUsd(config.minSellUsd)} USD)`
+      `• Faltante tras venta: ${fmtCup(plan.remainingCup)} CUP (≈ ${fmtUsd(plan.remainingUsd)} USD)`
     );
-  } else {
-    venta.push(sellNowLine);
+    venta.push('');
+    blocks.push(venta.join('\n'));
   }
-  venta.push(
-    `• Faltante tras venta: ${fmtCup(plan.remainingCup)} CUP (≈ ${fmtUsd(plan.remainingUsd)} USD)`
-  );
-  blocks.push(venta.join('\n'));
 
   if (hasBuyRate) {
     const excesoCupRaw = (activosCup || 0) - Math.abs(deudasCup || 0) - (cushionTarget || 0);
@@ -871,15 +890,17 @@ function renderAdvice(result) {
     if (excesoCup > 0) {
       const objetivoUsd = Math.floor(excesoCup / resolvedBuyRate);
       const objetivoCup = Math.round(objetivoUsd * resolvedBuyRate);
-      const compra = [
-        '💠 <b>Compra sugerida (USD)</b>',
-        `• Exceso sobre colchón/deudas: ${fmtCup(excesoCup)} CUP`,
-        `• Objetivo: comprar ${fmtUsd(objetivoUsd)} USD a ${fmtCup(resolvedBuyRate)} ⇒ −${fmtCup(objetivoCup)} CUP`,
-      ];
       if (objetivoUsd > 0) {
-        compra.push(`• Compra ahora: ${fmtUsd(objetivoUsd)} USD ⇒ −${fmtCup(objetivoCup)} CUP`);
+        const compra = [
+          '',
+          '💠 <b>Compra sugerida (USD)</b>',
+          `• Exceso sobre colchón/deudas: ${fmtCup(excesoCup)} CUP`,
+          `👇 Objetivo: comprar ${fmtUsd(objetivoUsd)} USD a ${fmtCup(resolvedBuyRate)} ⇒ −${fmtCup(objetivoCup)} CUP`,
+          `👇 Compra ahora: ${fmtUsd(objetivoUsd)} USD ⇒ −${fmtCup(objetivoCup)} CUP`,
+          '',
+        ];
+        blocks.push(compra.join('\n'));
       }
-      blocks.push(compra.join('\n'));
     }
   }
 

--- a/tests/__tests__/fondoAdvisor.test.js
+++ b/tests/__tests__/fondoAdvisor.test.js
@@ -120,8 +120,8 @@ describe('fondoAdvisor core calculations', () => {
     const message = blocks.join('\n\n');
     expect(Array.isArray(blocks)).toBe(true);
     expect(message).toContain('💸 <b>Venta requerida (Zelle)</b>');
-    expect(message).toContain('Objetivo: vender 348 USD a 452 ⇒ +157,296 CUP');
-    expect(message).toContain('Vende ahora: 200 USD ⇒ +90,400 CUP');
+    expect(message).toContain('👉 Objetivo: vender 348 USD a 452 ⇒ +157,296 CUP');
+    expect(message).toContain('👉 Vende ahora: 200 USD ⇒ +90,400 CUP');
     expect(message).toContain('Faltante tras venta: 66,710 CUP (≈ 148 USD)');
     expect(message).toContain('🧾 <b>Proyección post-venta</b>');
     expect(message).toContain('Colchón proyectado: 83,290 CUP');

--- a/tests/__tests__/middlewares/__snapshots__/fondoAdvisor.renderAdvice.test.js.snap
+++ b/tests/__tests__/middlewares/__snapshots__/fondoAdvisor.renderAdvice.test.js.snap
@@ -21,10 +21,12 @@ exports[`renderAdvice output formatting snapshot completo mantiene formato HTML 
 • Total: 180 USD
 • Disponible ahora: 180 USD
 
+
 💸 <b>Venta requerida (Zelle)</b>
-• Objetivo: vender 94 USD a 452 ⇒ +42,488 CUP
-• Vende ahora: 80 USD ⇒ +36,160 CUP
+👉 Objetivo: vender 94 USD a 452 ⇒ +42,488 CUP
+👉 Vende ahora: 80 USD ⇒ +36,160 CUP
 • Faltante tras venta: 6,061 CUP (≈ 14 USD)
+
 
 ────────────────────────────────
 


### PR DESCRIPTION
## Summary
- hide the sell recommendations block when every amount is zero
- add guidance emojis and blank-line spacing to the sell and buy advice blocks
- update fondoAdvisor messaging tests and snapshot expectations for the new format

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd445ba9a0832dac1c5226b488e9ae