### PR TITLE
Fix banco edit wizard cancellation handling

### DIFF
--- a/commands/banco.js
+++ b/commands/banco.js
@@ -72,7 +72,7 @@ const editarBancoWizard = new Scenes.WizardScene(
   'BANCO_EDIT_WIZ',
   // Paso 0: iniciar edición mostrando actual
   async (ctx) => {
-    if (await checkExit(ctx)) return;
+    if (await handleGlobalCancel(ctx)) return;
     console.log('[BANCO_EDIT_WIZ] Paso 0: iniciar edición');
     const edit = ctx.scene.state?.edit;
     if (!edit) {
@@ -91,7 +91,7 @@ const editarBancoWizard = new Scenes.WizardScene(
   },
   // Paso 1: nuevo código
   async (ctx) => {
-    if (await checkExit(ctx)) return;
+    if (await handleGlobalCancel(ctx)) return;
     console.log('[BANCO_EDIT_WIZ] Paso 1: recibí nuevo código:', ctx.message?.text);
     const input = (ctx.message?.text || '').trim().toUpperCase();
     if (input) ctx.wizard.state.data.newCodigo = input;
@@ -100,7 +100,7 @@ const editarBancoWizard = new Scenes.WizardScene(
   },
   // Paso 2: nuevo nombre
   async (ctx) => {
-    if (await checkExit(ctx)) return;
+    if (await handleGlobalCancel(ctx)) return;
     console.log('[BANCO_EDIT_WIZ] Paso 2: recibí nuevo nombre:', ctx.message?.text);
     const input = (ctx.message?.text || '').trim();
     if (input) ctx.wizard.state.data.newNombre = input;
@@ -109,7 +109,7 @@ const editarBancoWizard = new Scenes.WizardScene(
   },
   // Paso 3: emoji y aplicar actualización
   async (ctx) => {
-    if (await checkExit(ctx)) return;
+    if (await handleGlobalCancel(ctx)) return;
     console.log('[BANCO_EDIT_WIZ] Paso 3: recibí emoji:', ctx.message?.text);
     const emojiInput = (ctx.message?.text || '').trim();
     const state = ctx.wizard.state.data;

--- a/docs/commands/bancos.md
+++ b/docs/commands/bancos.md
@@ -18,3 +18,6 @@ Wizard multi-paso que permite crear, editar y eliminar bancos asociados a tarjet
 
 ## Dependencias
 - Requiere `psql/db.js` para consultar y modificar las tablas `banco` y `tarjeta`, y utiliza componentes de Telegraf (`Scenes`, `Markup`) para construir la interfaz de wizard.【F:commands/banco.js†L1-L259】
+
+## Notas de mantenimiento
+- La validación de cancelación en el wizard de edición reutiliza el helper `handleGlobalCancel`, evitando referencias a funciones inexistentes como `checkExit` y garantizando una salida consistente ante `/cancel` o "salir".【F:commands/banco.js†L71-L133】


### PR DESCRIPTION
## Summary
- use the existing handleGlobalCancel helper inside the banco edit wizard steps to prevent runtime ReferenceErrors
- document the cancellation helper usage in the /bancos command notes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5f3c9600c832d953e83c8f8a31c1b